### PR TITLE
Fix prix facture BL + priorisation prix BA + aperçu enrichi À facturer

### DIFF
--- a/app/api/delivery-notes/[id]/route.js
+++ b/app/api/delivery-notes/[id]/route.js
@@ -3,9 +3,10 @@
  * @description API pour un Bon de Livraison spécifique
  *              - GET: Récupérer un BL avec toutes ses relations + refs parent/child BO
  *              - PUT: Mettre à jour un BL (avec support backorder)
- * @version 1.2.0
- * @date 2026-03-04
+ * @version 1.3.0
+ * @date 2026-04-10
  * @changelog
+ *   1.3.0 - GET: charge client_po_items du BA lié pour accès aux prix BA dans facturation
  *   1.2.0 - Fix: INSERT matériaux résilient — retry sans colonnes BO si INSERT échoue
  *   1.1.1 - Fix: permettre quantité 0 dans matériaux (|| 1 convertissait 0 en 1)
  *   1.1.0 - Ajout support backorder (BO): ordered_quantity, previously_delivered
@@ -84,6 +85,21 @@ export async function GET(request, { params }) {
             selling_price: material.unit_price || 0
           };
         }
+      }
+    }
+
+    // Charger les items du BA lié (prix pour facturation)
+    if (data.linked_po_id && data.linked_po) {
+      try {
+        const { data: poItems } = await supabase
+          .from('client_po_items')
+          .select('product_id, description, quantity, unit, selling_price, cost_price')
+          .eq('purchase_order_id', data.linked_po_id);
+        if (poItems && poItems.length > 0) {
+          data.linked_po.items = poItems;
+        }
+      } catch (err) {
+        console.log('client_po_items non chargés:', err.message);
       }
     }
 

--- a/app/api/delivery-notes/route.js
+++ b/app/api/delivery-notes/route.js
@@ -245,7 +245,8 @@ export async function GET(request) {
         parent_bl_id,
         child_bl_id,
         client:clients(id, name),
-        linked_po:purchase_orders(id, po_number)
+        linked_po:purchase_orders(id, po_number),
+        materials:delivery_note_materials(id)
       `, { count: 'exact' })
       .order('bl_number', { ascending: false });
 

--- a/app/api/work-orders/route.js
+++ b/app/api/work-orders/route.js
@@ -288,7 +288,8 @@ export async function GET(request) {
         time_entries,
         invoice_id,
         client:clients(id, name),
-        linked_po:purchase_orders(id, po_number)
+        linked_po:purchase_orders(id, po_number),
+        materials:work_order_materials(id)
       `, { count: 'exact' })
       .order('bt_number', { ascending: false });
 

--- a/components/delivery-notes/DeliveryNoteForm.js
+++ b/components/delivery-notes/DeliveryNoteForm.js
@@ -9,9 +9,11 @@
  *              - Matériaux (réutilise MaterialSelector)
  *              - Support Backorder (BO): colonnes commandé/livré/BO, bandeau, liens parent/child
  *              Mobile-first: 95% usage tablette/mobile
- * @version 3.1.1
- * @date 2026-03-07
+ * @version 3.2.0
+ * @date 2026-04-10
  * @changelog
+ *   3.2.0 - Fix unit_price dans buildPayload: fallback product.selling_price pour que le prix
+ *           soit sauvegardé correctement dans delivery_note_materials
  *   3.1.1 - Fix curseur qui saute à la fin lors de la saisie dans les champs avec toUpperCase (CSS textTransform + onBlur)
  *   3.1.0 - Ajout attributs autoCorrect/autoCapitalize/spellCheck sur tous les champs texte
  *   3.0.0 - Refonte affichage BO: suppression section dupliquée "SUIVI COMMANDE / BACKORDER",
@@ -484,7 +486,7 @@ export default function DeliveryNoteForm({
           description: m.description || '',
           quantity: isNaN(parseFloat(m.quantity)) ? 1 : parseFloat(m.quantity),
           unit: m.unit || 'UN',
-          unit_price: parseFloat(m.unit_price) || 0,
+          unit_price: parseFloat(m.unit_price) || parseFloat(m.product?.selling_price) || 0,
           showPrice: m.showPrice || m.show_price || false,
           show_price: m.showPrice || m.show_price || false,
           notes: m.notes || '',

--- a/components/invoices/InvoiceEditor.js
+++ b/components/invoices/InvoiceEditor.js
@@ -10,7 +10,7 @@
  * @version 2.4.0
  * @date 2026-04-10
  * @changelog
- *   2.4.0 - Fix prix matériaux BL: ajout fallback product.selling_price dans generateBLLines()
+ *   2.4.0 - Fix prix matériaux BL: priorisation prix BA (client_po_items) > BL > inventaire
  *           Alignement fallbacks description/code produit BL avec BT
  *   2.3.0 - Ajout bouton "Imprimer" (génère PDF + marque envoyée, sans email)
  *           Affichage description BT/BL dans l'éditeur de facture
@@ -144,15 +144,28 @@ function generateBTLines(bt, settings) {
 
 /**
  * Génère les lignes de facture depuis un BL source
+ * Priorité prix: BA (client_po_items) > BL material > produit inventaire
  */
 function generateBLLines(bl) {
   const lines = [];
 
+  // Construire un map des prix BA par product_id
+  const baPriceMap = {};
+  if (bl.linked_po?.items) {
+    bl.linked_po.items.forEach(item => {
+      if (item.product_id && item.selling_price) {
+        baPriceMap[item.product_id] = parseFloat(item.selling_price);
+      }
+    });
+  }
+
   if (bl.materials && bl.materials.length > 0) {
     bl.materials.forEach((mat) => {
       const qty = mat.quantity || 0;
-      const price = mat.unit_price || mat.product?.selling_price || 0;
       const pid = mat.product_id || mat.code || null;
+      // Priorité: prix BA > prix BL material > prix produit inventaire
+      const baPrice = pid ? baPriceMap[pid] : undefined;
+      const price = baPrice || mat.unit_price || mat.product?.selling_price || 0;
       lines.push({
         id: `mat-${pid || mat.id || Math.random()}`,
         type: 'material',

--- a/components/invoices/InvoiceManager.js
+++ b/components/invoices/InvoiceManager.js
@@ -6,9 +6,10 @@
  *              - Actions: créer, voir, renvoyer, marquer payée
  *              - Rapport Acomba: export PDF + CSV mensuel ventilé
  *              - Numéros de référence cliquables (SplitView)
- * @version 1.6.0
- * @date 2026-03-16
+ * @version 1.7.0
+ * @date 2026-04-10
  * @changelog
+ *   1.7.0 - Enrichissement aperçu "À facturer": description, heures, transport, nb matériaux
  *   1.6.0 - Ajout bouton "Imprimer" sur factures (génère PDF + marque envoyée, sans email)
  *   1.5.0 - Fix: handleCreateInvoice utilise endpoint individuel pour récupérer matériaux + client complet (transport_fee, hourly_rate)
  *   1.4.0 - Ajout ReferenceLink sur N° BT/BL (Phase E — Numéros cliquables)
@@ -21,7 +22,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Receipt, FileText, Truck, DollarSign, RefreshCw, CheckCircle, Send, Eye, Clock, AlertCircle, Download, Archive, FileSpreadsheet, Printer } from 'lucide-react';
+import { Receipt, FileText, Truck, DollarSign, RefreshCw, CheckCircle, Send, Eye, Clock, AlertCircle, Download, Archive, FileSpreadsheet, Printer, Package } from 'lucide-react';
 import InvoiceEditor from './InvoiceEditor';
 import { generateAcombaReportPDF, generateAcombaReportCSV } from './AcombaReportExport';
 import { ReferenceLink } from '../SplitView';
@@ -455,6 +456,10 @@ export default function InvoiceManager() {
       _number: bt.bt_number,
       _date: bt.work_date,
       _clientName: bt.client?.name || 'Client inconnu',
+      _description: bt.work_description || '',
+      _totalHours: bt.total_hours || 0,
+      _hasTransport: bt.time_entries?.some(e => e.include_transport_fee) || false,
+      _materialCount: bt.materials?.length || 0,
     })),
     ...uninvoicedBL.map(bl => ({
       ...bl,
@@ -462,6 +467,10 @@ export default function InvoiceManager() {
       _number: bl.bl_number,
       _date: bl.delivery_date,
       _clientName: bl.client?.name || bl.client_name || 'Client inconnu',
+      _description: bl.delivery_description || '',
+      _totalHours: 0,
+      _hasTransport: false,
+      _materialCount: bl.materials?.length || 0,
     })),
   ].sort((a, b) => (b._date || '').localeCompare(a._date || ''));
 
@@ -625,6 +634,29 @@ export default function InvoiceManager() {
                       </div>
                       <div className="text-sm text-gray-700 dark:text-gray-300 font-medium">{item._clientName}</div>
                       <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">{formatDate(item._date)}</div>
+                      {item._description && (
+                        <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 truncate max-w-[280px]">{item._description}</div>
+                      )}
+                      <div className="flex items-center gap-3 mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                        {item._type === 'bt' && item._totalHours > 0 && (
+                          <span className="flex items-center gap-1">
+                            <Clock className="w-3 h-3" />
+                            {item._totalHours}h
+                          </span>
+                        )}
+                        {item._hasTransport && (
+                          <span className="flex items-center gap-1">
+                            <Truck className="w-3 h-3" />
+                            Transport
+                          </span>
+                        )}
+                        {item._materialCount > 0 && (
+                          <span className="flex items-center gap-1">
+                            <Package className="w-3 h-3" />
+                            {item._materialCount} article{item._materialCount > 1 ? 's' : ''}
+                          </span>
+                        )}
+                      </div>
                     </div>
                   ))}
                 </div>
@@ -634,11 +666,12 @@ export default function InvoiceManager() {
                   <table className="w-full">
                     <thead className="bg-gradient-to-r from-gray-50 to-emerald-50 dark:from-gray-800 dark:to-gray-800">
                       <tr>
-                        <th className="px-6 py-4 text-left text-sm font-semibold text-gray-700 dark:text-gray-300">Type</th>
-                        <th className="px-6 py-4 text-left text-sm font-semibold text-gray-700 dark:text-gray-300">N°</th>
-                        <th className="px-6 py-4 text-left text-sm font-semibold text-gray-700 dark:text-gray-300">Date</th>
-                        <th className="px-6 py-4 text-left text-sm font-semibold text-gray-700 dark:text-gray-300">Client</th>
-                        <th className="px-6 py-4 text-right text-sm font-semibold text-gray-700 dark:text-gray-300">Actions</th>
+                        <th className="px-4 py-4 text-left text-sm font-semibold text-gray-700 dark:text-gray-300">Type</th>
+                        <th className="px-4 py-4 text-left text-sm font-semibold text-gray-700 dark:text-gray-300">N°</th>
+                        <th className="px-4 py-4 text-left text-sm font-semibold text-gray-700 dark:text-gray-300">Date</th>
+                        <th className="px-4 py-4 text-left text-sm font-semibold text-gray-700 dark:text-gray-300">Client</th>
+                        <th className="px-4 py-4 text-left text-sm font-semibold text-gray-700 dark:text-gray-300">Détails</th>
+                        <th className="px-4 py-4 text-right text-sm font-semibold text-gray-700 dark:text-gray-300">Actions</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
@@ -648,7 +681,7 @@ export default function InvoiceManager() {
                             index % 2 === 0 ? 'bg-white/50 dark:bg-gray-800/50' : 'bg-gray-50/50 dark:bg-gray-900/30'
                           }`}
                         >
-                          <td className="px-6 py-3">
+                          <td className="px-4 py-3">
                             <span className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-semibold ${
                               item._type === 'bt'
                                 ? 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300'
@@ -658,7 +691,7 @@ export default function InvoiceManager() {
                               {item._type.toUpperCase()}
                             </span>
                           </td>
-                          <td className="px-6 py-3">
+                          <td className="px-4 py-3">
                             <ReferenceLink
                               type={item._type === 'bt' ? 'work-order' : 'delivery-note'}
                               label={item._number}
@@ -666,13 +699,38 @@ export default function InvoiceManager() {
                               variant={item._type === 'bt' ? 'green' : 'orange'}
                             />
                           </td>
-                          <td className="px-6 py-3 text-sm text-gray-600 dark:text-gray-400">
+                          <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">
                             {formatDate(item._date)}
                           </td>
-                          <td className="px-6 py-3 text-sm text-gray-900 dark:text-gray-100 font-medium">
+                          <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100 font-medium">
                             {item._clientName}
                           </td>
-                          <td className="px-6 py-3 text-right">
+                          <td className="px-4 py-3">
+                            {item._description && (
+                              <div className="text-xs text-gray-500 dark:text-gray-400 truncate max-w-[250px]" title={item._description}>{item._description}</div>
+                            )}
+                            <div className="flex items-center gap-2 mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                              {item._type === 'bt' && item._totalHours > 0 && (
+                                <span className="flex items-center gap-0.5">
+                                  <Clock className="w-3 h-3" />
+                                  {item._totalHours}h
+                                </span>
+                              )}
+                              {item._hasTransport && (
+                                <span className="flex items-center gap-0.5">
+                                  <Truck className="w-3 h-3" />
+                                  Transp.
+                                </span>
+                              )}
+                              {item._materialCount > 0 && (
+                                <span className="flex items-center gap-0.5">
+                                  <Package className="w-3 h-3" />
+                                  {item._materialCount}
+                                </span>
+                              )}
+                            </div>
+                          </td>
+                          <td className="px-4 py-3 text-right">
                             <div className="flex items-center justify-end gap-1.5">
                               <button
                                 onClick={() => handleMarkExternal(item)}


### PR DESCRIPTION
3 corrections dans le module Facturation:

1. DeliveryNoteForm: buildPayload() ajoute fallback product.selling_price pour que unit_price soit sauvé correctement dans delivery_note_materials

2. InvoiceEditor: generateBLLines() priorise les prix du BA (client_po_items) avant les prix BL et inventaire. API BL GET charge les items du BA lié.

3. InvoiceManager: aperçu "À facturer" enrichi avec description, heures, transport et nombre de matériaux (mobile + desktop). APIs liste BT/BL incluent maintenant le compteur de matériaux.

https://claude.ai/code/session_01DzGNbfsPWQsiKpMsuXsVFu