### PR TITLE
Fix company_name → company dans notes mouvements inventaire

### DIFF
--- a/app/api/admin/backfill-movements/route.js
+++ b/app/api/admin/backfill-movements/route.js
@@ -44,7 +44,7 @@ export async function GET(request) {
       .from('work_orders')
       .select(`
         id, bt_number, client_id, status,
-        client:clients(name, company_name),
+        client:clients(name, company),
         materials:work_order_materials(product_id, product_code, description, quantity, unit, unit_price)
       `)
       .in('status', ['signed', 'pending_send', 'sent', 'completed']);
@@ -71,7 +71,7 @@ export async function GET(request) {
         const materials = (wo.materials || []).filter(m => m.product_id && m.quantity);
         if (materials.length === 0) continue;
 
-        const clientName = wo.client?.company_name || wo.client?.name || 'Client';
+        const clientName = wo.client?.company || wo.client?.name || 'Client';
 
         for (const material of materials) {
           const qty = parseFloat(material.quantity) || 0;
@@ -144,7 +144,7 @@ export async function GET(request) {
       .from('delivery_notes')
       .select(`
         id, bl_number, client_id, client_name, status,
-        client:clients(name, company_name),
+        client:clients(name, company),
         materials:delivery_note_materials(product_id, description, quantity, unit, unit_price)
       `)
       .in('status', ['signed', 'pending_send', 'sent']);
@@ -171,7 +171,7 @@ export async function GET(request) {
         const materials = (dn.materials || []).filter(m => m.product_id && m.quantity);
         if (materials.length === 0) continue;
 
-        const clientName = dn.client?.company_name || dn.client?.name || dn.client_name || 'Client';
+        const clientName = dn.client?.company || dn.client?.name || dn.client_name || 'Client';
 
         for (const material of materials) {
           const qty = parseFloat(material.quantity) || 0;

--- a/app/api/work-orders/[id]/complete-signature/route.js
+++ b/app/api/work-orders/[id]/complete-signature/route.js
@@ -258,7 +258,7 @@ export async function POST(request, { params }) {
                 reference_type: 'work_order',
                 reference_id: workOrder.id.toString(),
                 reference_number: workOrder.bt_number,
-                notes: `BT ${workOrder.bt_number}${isCredit ? ' (CRÉDIT)' : ''} - ${workOrder.client?.company_name || workOrder.client?.name || 'Client'}`,
+                notes: `BT ${workOrder.bt_number}${isCredit ? ' (CRÉDIT)' : ''} - ${workOrder.client?.company || workOrder.client?.name || 'Client'}`,
                 created_at: new Date().toISOString()
               });
 

--- a/app/api/work-orders/[id]/send-email/route.js
+++ b/app/api/work-orders/[id]/send-email/route.js
@@ -246,7 +246,7 @@ export async function POST(request, { params }) {
                 reference_type: 'work_order',
                 reference_id: workOrder.id.toString(),
                 reference_number: workOrder.bt_number,
-                notes: `BT ${workOrder.bt_number}${isCredit ? ' (CRÉDIT)' : ''} - ${workOrder.client?.company_name || workOrder.client?.name || 'Client'}`,
+                notes: `BT ${workOrder.bt_number}${isCredit ? ' (CRÉDIT)' : ''} - ${workOrder.client?.company || workOrder.client?.name || 'Client'}`,
                 created_at: new Date().toISOString()
               });
 


### PR DESCRIPTION
La colonne clients.company_name n'existe pas, c'est clients.company. Corrigé dans:
- backfill-movements (select + notes)
- work-orders complete-signature (notes)
- work-orders send-email (notes)

https://claude.ai/code/session_01Xwar1uZXABn1K3cX1rfhJw