### PR TITLE
Fix reference_id UUID vs integer: utiliser reference_number pour BT/BL

### DIFF
--- a/app/api/admin/backfill-movements/route.js
+++ b/app/api/admin/backfill-movements/route.js
@@ -55,12 +55,12 @@ export async function GET(request) {
       results.workOrders.found = workOrders.length;
 
       for (const wo of workOrders) {
-        // Vérifier si des mouvements existent déjà
+        // Vérifier si des mouvements existent déjà (par reference_number car reference_id est UUID)
         const { data: existing } = await supabaseAdmin
           .from('inventory_movements')
           .select('id')
           .eq('reference_type', 'work_order')
-          .eq('reference_id', wo.id.toString())
+          .eq('reference_number', wo.bt_number)
           .limit(1);
 
         if (existing && existing.length > 0) {
@@ -93,7 +93,7 @@ export async function GET(request) {
             unit_cost: unitCost,
             total_cost: totalCost,
             reference_type: 'work_order',
-            reference_id: wo.id.toString(),
+            reference_id: null,
             reference_number: wo.bt_number,
             notes: `BT ${wo.bt_number}${isCredit ? ' (CRÉDIT)' : ''} - ${clientName} [rattrapage]`,
             created_at: new Date().toISOString()
@@ -155,12 +155,12 @@ export async function GET(request) {
       results.deliveryNotes.found = deliveryNotes.length;
 
       for (const dn of deliveryNotes) {
-        // Vérifier si des mouvements existent déjà
+        // Vérifier si des mouvements existent déjà (par reference_number car reference_id est UUID)
         const { data: existing } = await supabaseAdmin
           .from('inventory_movements')
           .select('id')
           .eq('reference_type', 'delivery_note')
-          .eq('reference_id', dn.id.toString())
+          .eq('reference_number', dn.bl_number)
           .limit(1);
 
         if (existing && existing.length > 0) {
@@ -193,7 +193,7 @@ export async function GET(request) {
             unit_cost: unitCost,
             total_cost: totalCost,
             reference_type: 'delivery_note',
-            reference_id: dn.id.toString(),
+            reference_id: null,
             reference_number: dn.bl_number,
             notes: `BL ${dn.bl_number}${isCredit ? ' (CRÉDIT)' : ''} - ${clientName} [rattrapage]`,
             created_at: new Date().toISOString()

--- a/app/api/delivery-notes/[id]/complete-signature/route.js
+++ b/app/api/delivery-notes/[id]/complete-signature/route.js
@@ -131,7 +131,7 @@ export async function POST(request, { params }) {
         .from('inventory_movements')
         .select('id')
         .eq('reference_type', 'delivery_note')
-        .eq('reference_id', deliveryNote.id.toString())
+        .eq('reference_number', deliveryNote.bl_number)
         .limit(1);
 
       if (existingMovements && existingMovements.length > 0) {
@@ -187,7 +187,7 @@ export async function POST(request, { params }) {
                 unit_cost: unitCost,
                 total_cost: totalCost,
                 reference_type: 'delivery_note',
-                reference_id: deliveryNote.id.toString(),
+                reference_id: null,
                 reference_number: deliveryNote.bl_number,
                 notes: `BL ${deliveryNote.bl_number}${isCredit ? ' (CRÉDIT)' : ''} - ${deliveryNote.client?.name || deliveryNote.client_name || 'Client'}`,
                 created_at: new Date().toISOString()

--- a/app/api/delivery-notes/[id]/send-email/route.js
+++ b/app/api/delivery-notes/[id]/send-email/route.js
@@ -149,7 +149,7 @@ export async function POST(request, { params }) {
       .from('inventory_movements')
       .select('id')
       .eq('reference_type', 'delivery_note')
-      .eq('reference_id', deliveryNote.id.toString())
+      .eq('reference_number', deliveryNote.bl_number)
       .limit(1);
 
     if (existingBLMovements && existingBLMovements.length > 0) {
@@ -201,7 +201,7 @@ export async function POST(request, { params }) {
               unit_cost: unitCost,
               total_cost: totalCost,
               reference_type: 'delivery_note',
-              reference_id: deliveryNote.id.toString(),
+              reference_id: null,
               reference_number: deliveryNote.bl_number,
               notes: `BL ${deliveryNote.bl_number}${isCredit ? ' (CRÉDIT)' : ''} - ${deliveryNote.client?.name || deliveryNote.client_name || 'Client'}`,
               created_at: new Date().toISOString()

--- a/app/api/work-orders/[id]/complete-signature/route.js
+++ b/app/api/work-orders/[id]/complete-signature/route.js
@@ -200,7 +200,7 @@ export async function POST(request, { params }) {
         .from('inventory_movements')
         .select('id')
         .eq('reference_type', 'work_order')
-        .eq('reference_id', workOrder.id.toString())
+        .eq('reference_number', workOrder.bt_number)
         .limit(1);
 
       if (existingMovements && existingMovements.length > 0) {
@@ -256,7 +256,7 @@ export async function POST(request, { params }) {
                 unit_cost: unitCost,
                 total_cost: totalCost,
                 reference_type: 'work_order',
-                reference_id: workOrder.id.toString(),
+                reference_id: null,
                 reference_number: workOrder.bt_number,
                 notes: `BT ${workOrder.bt_number}${isCredit ? ' (CRÉDIT)' : ''} - ${workOrder.client?.company || workOrder.client?.name || 'Client'}`,
                 created_at: new Date().toISOString()

--- a/app/api/work-orders/[id]/send-email/route.js
+++ b/app/api/work-orders/[id]/send-email/route.js
@@ -180,7 +180,7 @@ export async function POST(request, { params }) {
         .from('inventory_movements')
         .select('id')
         .eq('reference_type', 'work_order')
-        .eq('reference_id', workOrder.id.toString())
+        .eq('reference_number', workOrder.bt_number)
         .limit(1);
 
       if (existingBTMovements && existingBTMovements.length > 0) {
@@ -244,7 +244,7 @@ export async function POST(request, { params }) {
                 unit_cost: unitCost,
                 total_cost: totalCost,
                 reference_type: 'work_order',
-                reference_id: workOrder.id.toString(),
+                reference_id: null,
                 reference_number: workOrder.bt_number,
                 notes: `BT ${workOrder.bt_number}${isCredit ? ' (CRÉDIT)' : ''} - ${workOrder.client?.company || workOrder.client?.name || 'Client'}`,
                 created_at: new Date().toISOString()


### PR DESCRIPTION
La colonne reference_id dans inventory_movements est de type UUID, mais les IDs des work_orders et delivery_notes sont des integers. Les INSERT échouaient silencieusement avec "invalid input syntax for type uuid".

Corrections:
- reference_id: null (au lieu de .id.toString()) pour BT et BL
- Anti-doublon: .eq('reference_number', bt/bl_number) au lieu de .eq('reference_id', id.toString())
- Appliqué dans les 4 routes + le script de rattrapage

https://claude.ai/code/session_01Xwar1uZXABn1K3cX1rfhJw