### PR TITLE
Fix BT réservé: inclure aussi statut 'ready_for_signature'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -645,12 +645,13 @@ CRON_SECRET                   # Auth pour cron jobs
 - ~~Statut BL reste 'signed' au lieu de 'sent' après envoi email~~ → Corrigé (2026-02-17, PR #51)
 - ~~Caractères Unicode échappés dans DirectReceiptModal~~ → Corrigé (2026-02-18)
 - ~~Double-compte "Réservé (BT/BL/Soum.)" dans l'inventaire après signature~~ → Corrigé (2026-04-21, branche `claude/fix-inventory-shipment-sync-cI0hb`)
-  - `InventoryManager.js` v3.6.0 — BT réservé: `draft` uniquement; BL réservé: `draft` + `ready_for_signature`; soumissions retirées du calcul
+  - `InventoryManager.js` v3.6.0 — BT réservé: `draft` + `ready_for_signature`; BL réservé: `draft` + `ready_for_signature`; soumissions retirées du calcul
   - Raison: inventaire décrémenté à la signature (`complete-signature` v1.2.0+), donc les statuts `signed`/`pending_send` ne doivent plus compter en "Réservé"
   - Labels UI mis à jour: "Réservé (BT/BL non signés)" au lieu de "Réservé (BT/BL/Soum.)"
   - v3.7.0 (2026-04-21) — Outils de diagnostic ajoutés:
     - Bouton "Voir détail" dans modal édition → popup listant les BT/BL qui réservent l'item (N°, statut, client, qté)
     - Bouton "Avec réservé" dans barre d'outils → charge uniquement les items avec réservations actives
+  - v3.7.1 (2026-04-21) — Fix: ajout statut `ready_for_signature` pour BT (un BT ouvert via URL publique passe de draft → ready_for_signature, doit rester compté en réservé jusqu'à signature)
 
 ### Backup/Restauration
 - `/api/admin/restore` existe mais jamais testé

--- a/RECOMMANDATIONS.md
+++ b/RECOMMANDATIONS.md
@@ -1286,8 +1286,8 @@ Basees sur les reponses et decisions (2026-02-07), mis a jour 2026-02-22:
 - **Raison:** Depuis complete-signature v1.2.0 (2026-04-13), l'inventaire est deduit a la signature.
   Le calcul "Réservé" incluait encore les statuts `signed`/`pending_send` qui ont deja leur stock sorti.
 - **Decision (Martin):** Approche simple par statut:
-  - BT réservé: `draft` uniquement
-  - BL réservé: `draft` + `ready_for_signature` uniquement
+  - BT réservé: `draft` + `ready_for_signature` (un BT ouvert via URL publique passe en `ready_for_signature` via auto-correction dans `api/work-orders/[id]/public/route.js`)
+  - BL réservé: `draft` + `ready_for_signature`
   - Soumissions: retirees du calcul (items souvent pas en stock, non pertinent pour l'inventaire physique)
 - **Modele mental:** "Réservé" = items promis mais pas encore signés (stock encore en main).
   Une fois signé → stock parti → ne compte plus en reserve.

--- a/components/InventoryManager.js
+++ b/components/InventoryManager.js
@@ -8,9 +8,13 @@
  *              - Badge visuel Inventaire vs Non-inventaire
  *              - En main (stock_qty), En commande (AF), Réservé (BT/BL)
  *              - Modal unifié : Édition + Historique mouvements + Historique prix
- * @version 3.7.0
+ * @version 3.7.1
  * @date 2026-04-21
  * @changelog
+ *   3.7.1 - Fix BT réservé: inclure aussi le statut 'ready_for_signature' (pas seulement 'draft').
+ *           Un BT ouvert via l'URL publique pour signature passe de draft → ready_for_signature
+ *           (voir api/work-orders/[id]/public/route.js). Sans cet ajout, les BT en attente de
+ *           signature disparaissaient du calcul "Réservé".
  *   3.7.0 - Outils de diagnostic des réservations:
  *           - Bouton "Voir détail" à côté de "Réservé (BT/BL non signés)" dans le modal
  *             édition → popup listant chaque BT/BL qui réserve des unités (N°, statut,
@@ -285,12 +289,12 @@ export default function InventoryManager() {
         });
       }
 
-      // 2. Réservé BT: matériaux dans BT en brouillon uniquement
+      // 2. Réservé BT: matériaux dans BT en brouillon ou à signer
       //    (BT signé = stock déjà décrémenté via complete-signature, ne plus compter)
       const { data: workOrders, error: woError } = await supabase
         .from('work_orders')
         .select('id, bt_number, status, client:clients(name, company)')
-        .eq('status', 'draft');
+        .in('status', ['draft', 'ready_for_signature']);
 
       if (!woError && workOrders && workOrders.length > 0) {
         const woMap = Object.fromEntries(workOrders.map(wo => [wo.id, wo]));


### PR DESCRIPTION
Un BT ouvert via l'URL publique (pour signature client) passe de draft → ready_for_signature automatiquement (voir api/work-orders/[id]/public/route.js). Sans inclure ce statut, les BT en attente de signature disparaissaient du calcul "Réservé", alors qu'ils devraient y rester jusqu'à la signature.

BL réservé incluait déjà ready_for_signature - maintenant BT est aligné.