### PR TITLE
Ajout voyant marge faible dans l'éditeur de facture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -632,6 +632,14 @@ CRON_SECRET                   # Auth pour cron jobs
     - `lib/services/email-service.js` v3.2.0 — PDF BL avec colonnes Code/Desc/U/M/Commandé/Expédié/B/O conditionnelles
     - Note: Migration SQL à exécuter manuellement dans Supabase Dashboard
 
+17. ~~**Voyant marge faible (Facturation)**~~ - ✅ COMPLÉTÉ 2026-06-01
+    - `supabase/migrations/20260601_add_min_margin_percent.sql` — Colonne `min_margin_percent` (défaut 10)
+    - `app/api/settings/route.js` v1.2.0 — Champ `min_margin_percent` (défaut + validation)
+    - `app/(protected)/parametres/page.js` v2.2.0 — Champ "Marge de profit minimale" (section Facturation)
+    - `components/invoices/InvoiceEditor.js` v2.5.0 — Carré du prix vendant en rouge + icône ⚠️ + bandeau récapitulatif quand marge < seuil
+    - Alerte 100% interne (écran de saisie), jamais sur la facture client (PDF sans coûtant/marge)
+    - Note: Migration SQL à exécuter manuellement dans Supabase Dashboard
+
 ### À faire (priorité utilisateur)
 6. **Statut soumissions** - Import partiel + changement auto "Acceptée" + ref croisée BA
 7. **Bandeau alertes** - BA orphelins / AF reçus sans livraison (reste Phase 3)

--- a/RECOMMANDATIONS.md
+++ b/RECOMMANDATIONS.md
@@ -1365,6 +1365,25 @@ Basees sur les reponses et decisions (2026-02-07), mis a jour 2026-05-19:
     labels UI mis a jour, outils de diagnostic (modal + filtre)
   - `CLAUDE.md` — Ajout bug corrige dans section "Bugs connus"
 
+### 2026-06-01 - Voyant marge faible dans l'éditeur de facture
+- **Besoin (Martin):** Dans l'onglet Facturation, signaler quand le prix vendant d'un article
+  n'a pas une marge de profit suffisante. Si la marge est sous 10%, le carré du prix vendant
+  doit passer en rouge. Une marge laissée basse volontairement ne doit JAMAIS apparaître sur
+  la facture client.
+- **Decisions (Martin):**
+  - Seuil **configurable** dans Paramètres (`min_margin_percent`, défaut 10%)
+  - **Avertissement visuel** seulement (pas de bouton d'acquittement) — le rouge reste affiché
+  - **Bandeau récapitulatif** en haut de la facture comptant les articles sous le seuil
+- **Confidentialité:** Vérifié — le PDF facture (`email-service.js`) ne contient ni coûtant ni
+  marge. L'alerte est 100% interne à l'écran de saisie, jamais transmise au client.
+- **Calcul de marge:** `((vendant - coûtant) / coûtant) × 100`. Alerte seulement si coûtant > 0.
+- **Fichiers modifies/crees:**
+  - `supabase/migrations/20260601_add_min_margin_percent.sql` — Nouvelle colonne `min_margin_percent` (défaut 10)
+  - `app/api/settings/route.js` v1.2.0 — Champ `min_margin_percent` (défaut + validation 0-1000)
+  - `app/(protected)/parametres/page.js` v2.2.0 — Champ "Marge de profit minimale" (section Facturation)
+  - `components/invoices/InvoiceEditor.js` v2.5.0 — Carré prix vendant rouge + icône ⚠️ + bandeau
+- ⚠️ **Migration SQL à exécuter manuellement dans Supabase Dashboard**
+
 ---
 
-*Document genere le 2026-02-05, mis a jour le 2026-05-19 par Claude AI*
+*Document genere le 2026-02-05, mis a jour le 2026-06-01 par Claude AI*

--- a/app/(protected)/parametres/page.js
+++ b/app/(protected)/parametres/page.js
@@ -4,9 +4,10 @@
  *              - Section Apparence (thème clair/sombre)
  *              - Section Taux & Tarifs horaires (taux régulier, 1.5x, 2x, augmentation)
  *              - Section Facturation (numéros taxes, taux TPS/TVQ, conditions, N° facture)
- * @version 2.1.0
- * @date 2026-03-12
+ * @version 2.2.0
+ * @date 2026-06-01
  * @changelog
+ *   2.2.0 - Ajout champ Marge de profit minimale (min_margin_percent) - alerte facturation
  *   2.1.0 - Ajout champ Message de propriété (invoice_ownership_note)
  *   2.0.1 - Ajout attributs autoCorrect/autoCapitalize/spellCheck sur les champs texte
  *   2.0.0 - Ajout sections Taux & Tarifs et Facturation (Phase A Fondations)
@@ -419,6 +420,37 @@ export default function ParametresPage() {
                   />
                   <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500 dark:text-gray-400">%</span>
                 </div>
+              </div>
+            </div>
+
+            {/* Marge de profit minimale */}
+            <div className="border-t border-gray-200 dark:border-gray-700 pt-4">
+              <div className="max-w-xs">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Marge de profit minimale
+                </label>
+                <div className="relative">
+                  <input
+                    type="number"
+                    step="1"
+                    min="0"
+                    max="1000"
+                    className="w-full px-3 py-2 pr-8 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                    value={settings?.min_margin_percent ?? ''}
+                    onChange={(e) => updateField('min_margin_percent', parseFloat(e.target.value) || 0)}
+                    onFocus={(e) => e.target.select()}
+                    inputMode="decimal"
+                    placeholder="10"
+                    autoCorrect="off"
+                    autoCapitalize="off"
+                    spellCheck={false}
+                  />
+                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500 dark:text-gray-400">%</span>
+                </div>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  Sur une facture, le prix vendant d&apos;un article passe en rouge si sa marge
+                  est sous ce seuil. Alerte interne seulement &mdash; jamais affichée au client.
+                </p>
               </div>
             </div>
 

--- a/app/api/settings/route.js
+++ b/app/api/settings/route.js
@@ -4,9 +4,10 @@
  *              - GET: Récupère les paramètres (taux horaires, taxes, facturation)
  *              - PUT: Met à jour les paramètres
  *              - Table singleton (id=1 toujours)
- * @version 1.1.0
- * @date 2026-03-12
+ * @version 1.2.0
+ * @date 2026-06-01
  * @changelog
+ *   1.2.0 - Ajout champ min_margin_percent (seuil alerte marge faible facturation)
  *   1.1.0 - Ajout champ invoice_ownership_note (message propriété marchandises)
  *   1.0.0 - Version initiale (Phase A Fondations)
  */
@@ -47,6 +48,7 @@ export async function GET() {
             invoice_footer_note: '',
             invoice_ownership_note: '',
             invoice_next_number: 1,
+            min_margin_percent: 10,
           }
         });
       }
@@ -84,6 +86,7 @@ export async function PUT(request) {
       'invoice_footer_note',
       'invoice_ownership_note',
       'invoice_next_number',
+      'min_margin_percent',
     ];
 
     const updates = { updated_at: new Date().toISOString() };
@@ -115,6 +118,12 @@ export async function PUT(request) {
     if (updates.invoice_next_number !== undefined && updates.invoice_next_number < 1) {
       return NextResponse.json(
         { success: false, error: 'Le numéro de facture doit être au moins 1' },
+        { status: 400 }
+      );
+    }
+    if (updates.min_margin_percent !== undefined && (updates.min_margin_percent < 0 || updates.min_margin_percent > 1000)) {
+      return NextResponse.json(
+        { success: false, error: 'La marge minimale doit être entre 0 et 1000 %' },
         { status: 400 }
       );
     }

--- a/components/invoices/InvoiceEditor.js
+++ b/components/invoices/InvoiceEditor.js
@@ -7,9 +7,14 @@
  *              - Affiche coûtant unitaire et quantité en main pour les matériaux
  *              - Code produit cliquable ouvrant le vrai modal d'inventaire (éditable)
  *              - Actions: sauvegarder, envoyer, annuler
- * @version 2.4.1
- * @date 2026-04-13
+ *              - Voyant marge faible: carré du prix vendant en rouge si marge < seuil
+ *                (seuil configurable dans Paramètres, défaut 10%) + bandeau récapitulatif.
+ *                Alerte interne seulement — n'apparaît JAMAIS sur la facture client (PDF).
+ * @version 2.5.0
+ * @date 2026-06-01
  * @changelog
+ *   2.5.0 - Voyant marge faible: carré prix vendant rouge + icône avertissement + bandeau
+ *           récapitulatif quand marge < seuil min_margin_percent (Paramètres). Interne seulement.
  *   2.4.1 - Ajout traduction reference_type 'manual_edit' → 'Modification manuelle' dans historique mouvements
  *   2.4.0 - Fix prix matériaux BL: priorisation prix BA (client_po_items) > BL > inventaire
  *           Alignement fallbacks description/code produit BL avec BT
@@ -30,7 +35,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { X, Plus, Trash2, Save, Send, DollarSign, FileText, AlertCircle, Lock, Package, History, Edit, ArrowDownCircle, ArrowUpCircle, Printer } from 'lucide-react';
+import { X, Plus, Trash2, Save, Send, DollarSign, FileText, AlertCircle, AlertTriangle, Lock, Package, History, Edit, ArrowDownCircle, ArrowUpCircle, Printer } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
 import { buildPriceShiftUpdates } from '../../lib/utils/priceShift';
 
@@ -216,6 +221,9 @@ export default function InvoiceEditor({ source, invoice, settings, onClose }) {
   // Tax rates from settings
   const tpsRate = settings?.tps_rate || 5.0;
   const tvqRate = settings?.tvq_rate || 9.975;
+
+  // Seuil de marge minimale (alerte interne, jamais sur la facture client)
+  const minMarginPercent = settings?.min_margin_percent ?? 10;
 
   // Facture envoyée = verrouillée en lecture seule
   const isLocked = invoice?.status === 'sent' || invoice?.status === 'paid';
@@ -721,11 +729,31 @@ export default function InvoiceEditor({ source, invoice, settings, onClose }) {
     return `${(((selling - cost) / cost) * 100).toFixed(1)}%`;
   };
 
+  // True si la marge est sous le seuil minimal (coûtant connu et > 0 requis)
+  const isLowMargin = (costPrice, sellingPrice) => {
+    const cost = parseFloat(costPrice) || 0;
+    const selling = parseFloat(sellingPrice) || 0;
+    if (cost <= 0) return false;
+    const margin = ((selling - cost) / cost) * 100;
+    return margin < minMarginPercent;
+  };
+
   // Helper: get product info for a material line
   const getProductInfo = (line) => {
     const pid = line.product_id || line.detail;
     return pid ? productDataMap[pid] : null;
   };
+
+  // Nombre de lignes matériaux dont la marge est sous le seuil
+  const lowMarginCount = useMemo(() => {
+    return lineItems.reduce((count, line) => {
+      if (line.type !== 'material') return count;
+      const pid = line.product_id || line.detail;
+      const info = pid ? productDataMap[pid] : null;
+      if (info && isLowMargin(info.cost_price, line.unit_price)) return count + 1;
+      return count;
+    }, 0);
+  }, [lineItems, productDataMap, minMarginPercent]);
 
   const sourceNumber = invoice?.source_number || (sourceData && (source.type === 'bt' ? sourceData.bt_number : sourceData.bl_number)) || '';
   const clientName = invoice?.client_name || sourceData?.client?.name || sourceData?.client_name || '';
@@ -771,6 +799,17 @@ export default function InvoiceEditor({ source, invoice, settings, onClose }) {
           {success && (
             <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-3 text-sm text-green-700 dark:text-green-400">
               {success}
+            </div>
+          )}
+
+          {/* Bandeau alerte marge faible (interne — jamais sur la facture client) */}
+          {lowMarginCount > 0 && (
+            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 text-sm text-red-700 dark:text-red-400 flex items-start gap-2">
+              <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+              <span>
+                <strong>{lowMarginCount} article{lowMarginCount > 1 ? 's' : ''}</strong> sous la marge minimale de {minMarginPercent}&nbsp;% (carré du prix vendant en rouge).
+                Vérifiez le prix vendant ou laissez tel quel si c&apos;est voulu. Cette alerte reste interne et n&apos;apparaît pas sur la facture client.
+              </span>
             </div>
           )}
 
@@ -833,6 +872,7 @@ export default function InvoiceEditor({ source, invoice, settings, onClose }) {
               lineItems.map((line, index) => {
                 const productInfo = line.type === 'material' ? getProductInfo(line) : null;
                 const productCode = line.product_id || line.detail;
+                const lowMargin = !!(productInfo && isLowMargin(productInfo.cost_price, line.unit_price));
 
                 return (
                 <div
@@ -896,14 +936,22 @@ export default function InvoiceEditor({ source, invoice, settings, onClose }) {
                         />
                       </div>
                       <div>
-                        <label className="text-xs text-gray-500 dark:text-gray-400">Prix</label>
+                        <label className={`text-xs flex items-center gap-1 ${lowMargin ? 'text-red-600 dark:text-red-400 font-medium' : 'text-gray-500 dark:text-gray-400'}`}>
+                          {lowMargin && <AlertTriangle className="w-3 h-3" />}
+                          Prix
+                        </label>
                         <input
                           type="number"
                           value={line.unit_price}
                           onChange={(e) => updateLine(index, 'unit_price', e.target.value)}
                           onFocus={(e) => e.target.select()}
                           readOnly={isLocked}
-                          className={`w-full px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 dark:text-gray-200 text-sm text-right ${isLocked ? 'opacity-60' : ''}`}
+                          title={lowMargin ? `Marge sous le seuil de ${minMarginPercent}%` : undefined}
+                          className={`w-full px-2 py-1.5 border rounded text-sm text-right ${isLocked ? 'opacity-60' : ''} ${
+                            lowMargin
+                              ? 'border-red-500 dark:border-red-500 bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 font-semibold'
+                              : 'border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 dark:text-gray-200'
+                          }`}
                           inputMode="decimal"
                           step="0.01"
                           autoCorrect="off"
@@ -923,7 +971,8 @@ export default function InvoiceEditor({ source, invoice, settings, onClose }) {
                       <div className="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 rounded px-2 py-1.5">
                         <span>Coûtant: <span className="font-medium text-gray-700 dark:text-gray-300">{formatCurrency(productInfo.cost_price)}</span></span>
                         <span>En main: <span className="font-medium text-gray-700 dark:text-gray-300">{parseFloat(productInfo.stock_qty) || 0}</span></span>
-                        <span className={`font-medium ${getMarginColor(productInfo.cost_price, line.unit_price)}`}>
+                        <span className={`font-medium flex items-center gap-1 ${lowMargin ? 'text-red-600 dark:text-red-400' : getMarginColor(productInfo.cost_price, line.unit_price)}`}>
+                          {lowMargin && <AlertTriangle className="w-3 h-3" />}
                           {getMarginPercentage(productInfo.cost_price, line.unit_price)}
                         </span>
                       </div>
@@ -986,19 +1035,29 @@ export default function InvoiceEditor({ source, invoice, settings, onClose }) {
                         />
                       </div>
                       <div className="col-span-2 text-right">
-                        <input
-                          type="number"
-                          value={line.unit_price}
-                          onChange={(e) => updateLine(index, 'unit_price', e.target.value)}
-                          onFocus={(e) => e.target.select()}
-                          readOnly={isLocked}
-                          className={`w-full px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 dark:text-gray-200 text-sm text-right ${isLocked ? 'opacity-60' : ''}`}
-                          inputMode="decimal"
-                          step="0.01"
-                          autoCorrect="off"
-                          autoCapitalize="off"
-                          spellCheck={false}
-                        />
+                        <div className="relative">
+                          <input
+                            type="number"
+                            value={line.unit_price}
+                            onChange={(e) => updateLine(index, 'unit_price', e.target.value)}
+                            onFocus={(e) => e.target.select()}
+                            readOnly={isLocked}
+                            title={lowMargin ? `Marge sous le seuil de ${minMarginPercent}%` : undefined}
+                            className={`w-full px-2 py-1.5 border rounded text-sm text-right ${isLocked ? 'opacity-60' : ''} ${
+                              lowMargin
+                                ? 'border-red-500 dark:border-red-500 bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 font-semibold pr-7'
+                                : 'border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 dark:text-gray-200'
+                            }`}
+                            inputMode="decimal"
+                            step="0.01"
+                            autoCorrect="off"
+                            autoCapitalize="off"
+                            spellCheck={false}
+                          />
+                          {lowMargin && (
+                            <AlertTriangle className="w-4 h-4 text-red-600 dark:text-red-400 absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none" />
+                          )}
+                        </div>
                       </div>
                       <div className="col-span-1 text-right text-sm font-semibold text-gray-900 dark:text-gray-100">
                         {formatCurrency(line.total)}
@@ -1022,8 +1081,10 @@ export default function InvoiceEditor({ source, invoice, settings, onClose }) {
                         <div className="col-span-8 flex items-center gap-4 text-xs text-gray-500 dark:text-gray-400 pl-1">
                           <span>Coûtant: <span className="font-medium text-gray-700 dark:text-gray-300">{formatCurrency(productInfo.cost_price)}</span></span>
                           <span>En main: <span className="font-medium text-gray-700 dark:text-gray-300">{parseFloat(productInfo.stock_qty) || 0}</span></span>
-                          <span className={`font-medium ${getMarginColor(productInfo.cost_price, line.unit_price)}`}>
+                          <span className={`font-medium flex items-center gap-1 ${lowMargin ? 'text-red-600 dark:text-red-400' : getMarginColor(productInfo.cost_price, line.unit_price)}`}>
+                            {lowMargin && <AlertTriangle className="w-3 h-3" />}
                             Marge: {getMarginPercentage(productInfo.cost_price, line.unit_price)}
+                            {lowMargin && ` (< ${minMarginPercent}%)`}
                           </span>
                           {productInfo.supplier && (
                             <span>Fourn.: <span className="font-medium text-gray-700 dark:text-gray-300">{productInfo.supplier}</span></span>

--- a/supabase/migrations/20260601_add_min_margin_percent.sql
+++ b/supabase/migrations/20260601_add_min_margin_percent.sql
@@ -1,0 +1,14 @@
+-- Migration: Marge de profit minimale (alerte facturation)
+-- Date: 2026-06-01
+-- Description:
+--   Ajoute une colonne min_margin_percent à la table settings.
+--   Utilisée dans l'éditeur de facture pour signaler (voyant rouge)
+--   les articles dont la marge de profit (vendant vs coûtant) est sous le seuil.
+--   Purement interne : n'apparaît JAMAIS sur la facture client (PDF).
+
+ALTER TABLE settings
+  ADD COLUMN IF NOT EXISTS min_margin_percent NUMERIC NOT NULL DEFAULT 10;
+-- Seuil de marge minimale en % (ex: 10 = alerte si marge < 10%)
+
+-- S'assurer que la ligne singleton existante a une valeur
+UPDATE settings SET min_margin_percent = 10 WHERE min_margin_percent IS NULL;


### PR DESCRIPTION
Signale les articles dont le prix vendant est sous la marge de profit minimale: carré du prix vendant en rouge + icône avertissement + bandeau récapitulatif en haut de la facture. Seuil configurable dans Paramètres (min_margin_percent, défaut 10%).

Alerte 100% interne à l'écran de saisie — n'apparaît jamais sur la facture client (le PDF ne contient ni coûtant ni marge).

- migration 20260601_add_min_margin_percent.sql (nouvelle colonne settings)
- API settings v1.2.0 (champ + validation)
- page Paramètres v2.2.0 (champ "Marge de profit minimale")
- InvoiceEditor v2.5.0 (voyant rouge + bandeau)

https://claude.ai/code/session_01XBbiitpvDWd4xHeyP2aK2V