### PR TITLE
Normaliser les courriels BT/BL/Factures + avis no-reply Resend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,37 @@ return NextResponse.json(
 );
 ```
 
+### Courriels (Resend / no-reply) — OBLIGATOIRE
+
+Tous les courriels sont envoyés depuis une adresse **no-reply** de Resend
+(`noreply@servicestmt.ca`). Le client ne peut donc PAS répondre directement.
+
+**Règle 1 — Avis no-reply obligatoire:** Chaque courriel envoyé au client
+(BT, BL, Factures) DOIT contenir l'avis suivant, juste avant le pied de page :
+
+```html
+<p style="color: #999; font-size: 13px; font-style: italic;">
+  Ne pas répondre à ce courriel.<br>
+  Pour nous contacter, utilisez le lien ci-dessous.
+</p>
+```
+
+Dans le courriel de **facture**, cet avis se place sous la ligne
+« N'hésitez pas à nous contacter pour toute question. »
+
+**Règle 2 — Lien de contact cliquable:** Le « lien ci-dessous » est l'adresse
+courriel de l'entreprise dans le pied de page, rendue cliquable via `mailto:` :
+
+```html
+<a href="mailto:info.servicestmt@gmail.com">info.servicestmt@gmail.com</a>
+```
+
+**Règle 3 — Format visuel unifié:** Les courriels BT, BL et Factures partagent
+le même gabarit visuel (carte blanche centrée, max 600px, en-tête + corps +
+avis no-reply + pied de page). Pour BT/BL, utiliser le helper
+`buildStandardEmailHTML()` dans `lib/services/email-service.js`. Le courriel de
+facture (`app/api/invoices/[id]/send-email/route.js`) suit le même format.
+
 ### Taxes Québec
 
 ```javascript

--- a/app/api/invoices/[id]/send-email/route.js
+++ b/app/api/invoices/[id]/send-email/route.js
@@ -6,9 +6,11 @@
  *              - Sauvegarde pdf_url dans la table invoices
  *              - Envoie par Resend au client (cascade email)
  *              - Met à jour le statut de la facture à 'sent'
- * @version 1.3.0
- * @date 2026-03-16
+ * @version 1.4.0
+ * @date 2026-06-04
  * @changelog
+ *   1.4.0 - Ajout avis no-reply Resend (sous "N'hésitez pas à nous contacter")
+ *           + lien de contact cliquable (mailto) dans le pied de page du courriel
  *   1.3.0 - Ajout mode print_only: génère PDF + upload Storage + marque envoyée
  *           sans envoyer d'email (pour clients sans adresse email / envoi postal)
  *           Ajout source_description (work_description/delivery_description) sur PDF
@@ -361,12 +363,16 @@ export async function POST(request, { params }) {
             ${invoice.payment_terms ? `<p><strong>Conditions:</strong> ${invoice.payment_terms}</p>` : ''}
             ${invoice.due_date ? `<p><strong>Échéance:</strong> ${invoice.due_date}</p>` : ''}
             <p>N'hésitez pas à nous contacter pour toute question.</p>
+            <p style="color: #999; font-size: 13px; font-style: italic; margin: 20px 0 0;">
+              Ne pas répondre à ce courriel.<br>
+              Pour nous contacter, utilisez le lien ci-dessous.
+            </p>
             <hr style="border: none; border-top: 1px solid #ddd; margin: 20px 0;">
             <p style="color: #666; font-size: 13px;">
               ${companyName}<br>
               ${pdfCommon.COMPANY.address}, ${pdfCommon.COMPANY.city}<br>
               Tél: ${pdfCommon.COMPANY.phone}<br>
-              ${pdfCommon.COMPANY.email}
+              <a href="mailto:${pdfCommon.COMPANY.email}" style="color: #2563eb;">${pdfCommon.COMPANY.email}</a>
             </p>
           </div>
         </body>

--- a/lib/services/email-service.js
+++ b/lib/services/email-service.js
@@ -3,9 +3,11 @@
  * @description Service d'envoi email + génération PDF pour les Bons de Travail (BT)
  *              et les Bons de Livraison (BL)
  *              Utilise pdf-common.js pour l'en-tête, footer et table standardisés
- * @version 3.3.0
- * @date 2026-04-08
+ * @version 3.4.0
+ * @date 2026-06-04
  * @changelog
+ *   3.4.0 - Normalisation visuelle des courriels BT/BL (carte blanche, comme la facture)
+ *           via buildStandardEmailHTML() + avis no-reply Resend + lien de contact cliquable
  *   3.3.0 - Ajout session_description (optionnel) dans les lignes heures du PDF BT
  *   3.2.0 - Fix colonnes PDF BL BO: Code/Description/U/M/Commandé/Expédié/B/O
  *           Note simplifiée "Certains items seront livrés ultérieurement."
@@ -76,6 +78,46 @@ const COMPANY_CONFIG = {
   ...pdfCommon.COMPANY,
   resendFrom: process.env.RESEND_FROM_EMAIL || 'noreply@servicestmt.com'
 };
+
+/**
+ * Génère le HTML standardisé des courriels (BT, BL, Factures).
+ * Format visuel unifié: carte blanche centrée, avis no-reply (Resend) et
+ * pied de page avec lien de contact cliquable.
+ *
+ * @param {Object} opts
+ * @param {string} opts.title      Titre affiché (ex: "Bon de Travail BT-...")
+ * @param {string} opts.greeting   Salutation (ex: "Bonjour Jean,")
+ * @param {string[]} opts.paragraphs Paragraphes du corps (HTML autorisé)
+ * @returns {string} HTML complet du courriel
+ */
+function buildStandardEmailHTML({ title, greeting, paragraphs = [] }) {
+  const body = paragraphs
+    .map((p) => `<p style="color: #333; line-height: 1.5; margin: 0 0 12px;">${p}</p>`)
+    .join('\n            ');
+
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: Arial, sans-serif; margin: 0; padding: 20px; background-color: #f5f5f5;">
+  <div style="max-width: 600px; margin: 0 auto; background: #ffffff; padding: 30px; border-radius: 8px;">
+    <h2 style="color: #333; margin-bottom: 20px;">${title}</h2>
+    <p style="color: #333; margin: 0 0 12px;">${greeting}</p>
+            ${body}
+    <p style="color: #999; font-size: 13px; font-style: italic; margin: 20px 0 0;">
+      Ne pas répondre à ce courriel.<br>
+      Pour nous contacter, utilisez le lien ci-dessous.
+    </p>
+    <hr style="border: none; border-top: 1px solid #ddd; margin: 20px 0;">
+    <p style="color: #666; font-size: 13px;">
+      ${COMPANY_CONFIG.name}<br>
+      ${COMPANY_CONFIG.address}, ${COMPANY_CONFIG.city}<br>
+      Tél: ${COMPANY_CONFIG.phone}<br>
+      <a href="mailto:${COMPANY_CONFIG.email}" style="color: #2563eb;">${COMPANY_CONFIG.email}</a>
+    </p>
+  </div>
+</body>
+</html>`;
+}
 
 // Charger le logo en base64 au démarrage (une seule fois)
 let LOGO_BASE64 = null;
@@ -380,18 +422,15 @@ class WorkOrderEmailService {
   }
 
   getEmailTemplate(workOrder) {
-    let html = '<!DOCTYPE html><html><head><meta charset="utf-8">';
-    html += '<style>body { font-family: Arial, sans-serif; }</style>';
-    html += '</head><body>';
-    html += '<h2>' + COMPANY_CONFIG.name + '</h2>';
-    html += '<h2>Bon de Travail ' + workOrder.bt_number + '</h2>';
-    html += '<p>Bonjour ' + workOrder.client.name + ',</p>';
-    html += '<p>Veuillez trouver en pièce jointe le bon de travail complété.</p>';
-    html += '<p>Merci de votre confiance.</p>';
-    html += '<p>' + COMPANY_CONFIG.name + '<br>' + COMPANY_CONFIG.address + '<br>' + COMPANY_CONFIG.city + '</p>';
-    html += '</body></html>';
-    
-    return html;
+    return buildStandardEmailHTML({
+      title: 'Bon de Travail ' + workOrder.bt_number,
+      greeting: 'Bonjour ' + workOrder.client.name + ',',
+      paragraphs: [
+        'Veuillez trouver en pièce jointe le bon de travail complété.',
+        'Merci de votre confiance.',
+        'N\'hésitez pas à nous contacter pour toute question.',
+      ],
+    });
   }
 
   async sendWorkOrderEmail(workOrder, options = {}) {
@@ -815,18 +854,15 @@ class DeliveryNoteEmailService {
   }
 
   getEmailTemplate(deliveryNote) {
-    let html = '<!DOCTYPE html><html><head><meta charset="utf-8">';
-    html += '<style>body { font-family: Arial, sans-serif; }</style>';
-    html += '</head><body>';
-    html += '<h2>' + COMPANY_CONFIG.name + '</h2>';
-    html += '<h2>Bon de Livraison ' + deliveryNote.bl_number + '</h2>';
-    html += '<p>Bonjour ' + (deliveryNote.client?.name || deliveryNote.client_name || '') + ',</p>';
-    html += '<p>Veuillez trouver en pièce jointe le bon de livraison.</p>';
-    html += '<p>Merci de votre confiance.</p>';
-    html += '<p>' + COMPANY_CONFIG.name + '<br>' + COMPANY_CONFIG.address + '<br>' + COMPANY_CONFIG.city + '</p>';
-    html += '</body></html>';
-
-    return html;
+    return buildStandardEmailHTML({
+      title: 'Bon de Livraison ' + deliveryNote.bl_number,
+      greeting: 'Bonjour ' + (deliveryNote.client?.name || deliveryNote.client_name || '') + ',',
+      paragraphs: [
+        'Veuillez trouver en pièce jointe le bon de livraison.',
+        'Merci de votre confiance.',
+        'N\'hésitez pas à nous contacter pour toute question.',
+      ],
+    });
   }
 
   async sendDeliveryNoteEmail(deliveryNote, options = {}) {


### PR DESCRIPTION
- Ajout d'un gabarit visuel unifie (carte blanche, comme la facture) pour les courriels BT et BL via buildStandardEmailHTML() dans email-service.js
- Avis no-reply ajoute a tous les courriels client (BT, BL, Factures): "Ne pas repondre a ce courriel. Pour nous contacter, utilisez le lien ci-dessous."
- Lien de contact rendu cliquable (mailto) dans le pied de page
- Documentation de la regle dans CLAUDE.md (section Courriels)

https://claude.ai/code/session_01RbvZQp9Fh8ZtynVGuvRDRy