### PR TITLE
Fix BCC B/O client + import fournisseur au prix vendant

### DIFF
--- a/components/PurchaseOrder/BCCConfirmationModal.js
+++ b/components/PurchaseOrder/BCCConfirmationModal.js
@@ -5,9 +5,11 @@
  *              - Permet d'ajouter un délai de livraison par article
  *              - Sélection des destinataires email (contacts client)
  *              - Génère un PDF BCC et l'envoie par email via l'API
- * @version 1.6.0
- * @date 2026-04-01
+ * @version 1.6.1
+ * @date 2026-06-05
  * @changelog
+ *   1.6.1 - Fix B/O: plafonne la quantité B/O affichée au client à la quantité commandée par le client
+ *           (évite d'afficher les unités commandées en surplus au fournisseur pour l'inventaire)
  *   1.6.0 - Quantité éditable dans BCC: modifie aussi la quantité dans l'onglet Articles du BA
  *   1.5.1 - Ajout attributs autoCorrect/autoCapitalize/spellCheck sur textarea notes
  *   1.5.0 - Ajout support dark mode
@@ -209,7 +211,10 @@ const BCCConfirmationModal = ({ isOpen, onClose, purchaseOrder, items: baItems, 
         const unitPrice = parseFloat(item.selling_price || 0);
         const qtyDelivered = deliveredQuantities[code] || 0;
         const afInfo = afQuantities[code] || { ordered: 0, received: 0 };
-        const qtyBackorder = Math.max(0, afInfo.ordered - afInfo.received);
+        // Le B/O affiché au client ne doit JAMAIS dépasser ce qu'il a commandé.
+        // (On peut commander plus d'unités au fournisseur pour l'inventaire, mais
+        //  ces unités supplémentaires ne concernent pas le client.)
+        const qtyBackorder = Math.min(qtyCmd, Math.max(0, afInfo.ordered - afInfo.received));
 
         return {
           code: code,

--- a/components/PurchaseOrderModal.js
+++ b/components/PurchaseOrderModal.js
@@ -5,9 +5,11 @@
  *              - Import depuis soumissions et achats fournisseurs
  *              - Gestion des bons de livraison liés
  *              - Modal BCC (confirmation de commande)
- * @version 1.2.0
- * @date 2026-04-01
+ * @version 1.2.1
+ * @date 2026-06-05
  * @changelog
+ *   1.2.1 - Import Fournisseurs: utilise le prix vendant (selling_price) au lieu du coûtant (cost_price)
+ *           pour afficher le vrai prix de vente au client (import + aperçu + total estimé)
  *   1.2.0 - Propagation changement quantité depuis BCC vers onglet Articles (onQuantityChange)
  *   1.1.3 - Fix curseur qui saute à la fin lors de la saisie dans les champs avec toUpperCase (CSS textTransform + onBlur)
  *   1.1.2 - Ajout attributs autoCorrect/autoCapitalize/spellCheck sur tous les champs texte
@@ -199,7 +201,7 @@ const PurchaseOrderModal = ({ isOpen, onClose, editingPO = null, onRefresh, pane
           description: supplierItem.description || supplierItem.name || supplierItem.product_name || 'Article importé',
           quantity: parseFloat(supplierItem.quantity || supplierItem.qty || 1),
           unit: supplierItem.unit || supplierItem.unity || 'unité',
-          selling_price: parseFloat(supplierItem.cost_price || supplierItem.price || supplierItem.unit_price || 0),
+          selling_price: parseFloat(supplierItem.selling_price || supplierItem.price || supplierItem.unit_price || supplierItem.cost_price || 0),
           delivered_quantity: 0,
           from_supplier_purchase: true,
           supplier_purchase_id: selectedPurchaseForImport.id,
@@ -2679,7 +2681,7 @@ setTimeout(() => {
                           <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
                             {(selectedPurchaseForImport.items || []).map((item, index) => {
                               const quantity = parseFloat(item.quantity || item.qty || 1);
-                              const unitPrice = parseFloat(item.cost_price || item.price || item.unit_price || 0);
+                              const unitPrice = parseFloat(item.selling_price || item.price || item.unit_price || item.cost_price || 0);
                               const lineTotal = quantity * unitPrice;
                               
                               return (
@@ -2718,7 +2720,7 @@ setTimeout(() => {
                           Total estimé: ${selectedItemsForImport.reduce((sum, itemIndex) => {
                             const item = selectedPurchaseForImport.items[itemIndex];
                             const quantity = parseFloat(item.quantity || item.qty || 1);
-                            const unitPrice = parseFloat(item.cost_price || item.price || item.unit_price || 0);
+                            const unitPrice = parseFloat(item.selling_price || item.price || item.unit_price || item.cost_price || 0);
                             return sum + (quantity * unitPrice);
                           }, 0).toFixed(2)}
                         </p>


### PR DESCRIPTION
- BCC: plafonne la quantité B/O affichée au client à la quantité qu'il a réellement commandée. Auparavant, si on commandait plus d'unités au fournisseur (pour l'inventaire), le surplus s'affichait en B/O sur le BCC du client.
- Import Fournisseurs (onglet Articles du BA): les items importés utilisent désormais leur prix vendant (selling_price) au lieu du coûtant (cost_price), afin d'afficher le vrai prix de vente au client (logique appliquée à l'import, l'aperçu et le total estimé).