### PR TITLE
Notes: client associable + filtrage des documents liables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,7 +359,7 @@ const total = subtotal + tps + tvq;
 ```
 /api/notes                             → CRUD Notes (GET liste + POST création)
 /api/notes/[id]                        → GET/PUT (édition + toggle complété)/DELETE note
-/api/notes/projects                    → Liste BT/BL/BA/Soumission pour sélecteur de note
+/api/notes/projects                    → Liste BT/BL/BA/Soumission pour sélecteur de note (filtrée: brouillons BT/BL, BA en cours, soum. envoyées/acceptées + filtre client)
 /api/work-orders                       → CRUD BT
 /api/work-orders/[id]/send-email       → Envoi email BT
 /api/work-orders/[id]/signature        → Capture signature BT
@@ -498,6 +498,7 @@ sent_at, paid_at, user_id, created_at, updated_at
 id (UUID), title, description,
 note_type ('global'|'project'),
 project_type ('work_order'|'delivery_note'|'purchase_order'|'submission'), project_id, project_number,
+client_id, client_name,
 due_date, completed, completed_at,
 user_id, created_at, updated_at
 ```
@@ -712,7 +713,11 @@ CRON_SECRET                   # Auth pour cron jobs
     - `components/Navigation.js` v2.1.0 — Onglet Notes (1er) + badge urgent
     - Notes globales OU liées à un document; complétées masquées; lien projet ouvre le SplitView
     - Décisions: `.js` (pas TS), en ligne simple (pas d'offline-first), échéance optionnelle, sans priorité/tags
-    - **Reste:** exécuter la migration SQL dans Supabase Dashboard
+    - **Amélioration (2026-06-09):** Client associable à une note (optionnel) + filtrage du sélecteur de document
+      - `supabase/migrations/20260609b_add_client_to_notes.sql` — colonnes `client_id` + `client_name`
+      - `app/api/notes/projects/route.js` v2.0.0 — n'affiche que: BT/BL `draft` (Brouillons), BA `in_progress` (En cours), Soumissions `sent`/`accepted` (Envoyée/Acceptée); filtre par client (client_id BT/BL, client_name BA/Soum.)
+      - `NoteForm.js` v1.1.0 (sélecteur client) + `NoteCard.js` v1.1.0 (badge client) + API notes route/[id] v1.1.0
+    - **Reste:** exécuter les migrations SQL (`20260609_create_notes.sql` + `20260609b_add_client_to_notes.sql`) dans Supabase Dashboard
 
 ### À faire (priorité utilisateur)
 6. **Statut soumissions** - Import partiel + changement auto "Acceptée" + ref croisée BA

--- a/RECOMMANDATIONS.md
+++ b/RECOMMANDATIONS.md
@@ -1478,6 +1478,25 @@ coloration selon l'urgence, masquage des notes complétées.
 
 **Note:** La migration SQL doit être exécutée manuellement dans Supabase Dashboard.
 
+### Amélioration — Client sur les notes + filtrage des documents ✅ COMPLETE (2026-06-09)
+
+**Demande utilisateur:** Pouvoir associer un client à une note (au besoin). Le client sert
+aussi à filtrer le sélecteur de document. De plus, ne montrer que les documents pertinents :
+BT/BL en **Brouillon** uniquement (pas les envoyés), BA **En cours** uniquement, Soumissions
+**Envoyée** et **Acceptée** uniquement.
+
+**Implémentation:**
+- `supabase/migrations/20260609b_add_client_to_notes.sql` — Colonnes `client_id` + `client_name` + index
+- `app/api/notes/projects/route.js` v2.0.0 — Filtres par statut (BT/BL `draft`, BA `in_progress`,
+  Soumissions `sent`/`accepted`) + filtre par client (`client_id` pour BT/BL, `client_name` pour BA/Soumission)
+- `app/api/notes/route.js` v1.1.0 — POST accepte `client_id` / `client_name`
+- `app/api/notes/[id]/route.js` v1.1.0 — PUT accepte `client_id` / `client_name`
+- `components/notes/NoteForm.js` v1.1.0 — Sélecteur de client (optionnel) qui filtre les documents liables
+- `components/notes/NoteCard.js` v1.1.0 — Badge client sur la carte
+- `components/notes/NotesManager.js` — Recherche inclut le nom du client
+
+**Note:** La migration SQL `20260609b_add_client_to_notes.sql` doit être exécutée manuellement dans Supabase Dashboard.
+
 ---
 
 *Document genere le 2026-02-05, mis a jour le 2026-06-09 par Claude AI*

--- a/app/api/notes/[id]/route.js
+++ b/app/api/notes/[id]/route.js
@@ -4,9 +4,10 @@
  *              - GET: Récupère une note
  *              - PUT: Met à jour une note (édition + toggle complété)
  *              - DELETE: Supprime définitivement une note
- * @version 1.0.0
+ * @version 1.1.0
  * @date 2026-06-09
  * @changelog
+ *   1.1.0 - Support du client associé à une note (client_id, client_name)
  *   1.0.0 - Version initiale (Système de Notes MVP)
  */
 
@@ -98,6 +99,14 @@ export async function PUT(request, { params }) {
         updates.project_id = body.project_id;
         updates.project_number = body.project_number || null;
       }
+    }
+
+    // Client associé (optionnel, indépendant du lien projet)
+    if (body.client_id !== undefined) {
+      updates.client_id = body.client_id || null;
+    }
+    if (body.client_name !== undefined) {
+      updates.client_name = body.client_name ? String(body.client_name).trim() : null;
     }
 
     // Toggle complété

--- a/app/api/notes/projects/route.js
+++ b/app/api/notes/projects/route.js
@@ -3,9 +3,19 @@
  * @description Fournit la liste des documents liables à une note (BT/BL/BA/Soumission)
  *              pour le sélecteur du formulaire de note. Retourne { id, number, client_name }.
  *              Utilise supabaseAdmin (bypass RLS) comme les autres routes API.
- * @version 1.0.0
+ *
+ *              Filtres appliqués (toujours, pour ne montrer que les documents pertinents):
+ *                - BT (work_order)      : statut 'draft' (Brouillons seulement)
+ *                - BL (delivery_note)   : statut 'draft' (Brouillons seulement)
+ *                - BA (purchase_order)  : statut 'in_progress' (En cours seulement)
+ *                - Soumission           : statut 'sent' ou 'accepted' (Envoyée / Acceptée)
+ *
+ *              Filtre client optionnel (client_id pour BT/BL, client_name pour BA/Soumission).
+ * @version 2.0.0
  * @date 2026-06-09
  * @changelog
+ *   2.0.0 - Filtres par statut (BT/BL brouillons, BA en cours, Soumissions envoyées/acceptées)
+ *           + filtre par client (client_id / client_name)
  *   1.0.0 - Version initiale (Système de Notes MVP)
  */
 
@@ -18,13 +28,20 @@ export const revalidate = 0;
 const LIMIT = 150;
 
 /**
- * GET /api/notes/projects?type=work_order|delivery_note|purchase_order|submission&search=...
+ * GET /api/notes/projects
+ * Query params:
+ *   - type: work_order | delivery_note | purchase_order | submission (requis)
+ *   - search: filtre sur le numéro de document (optionnel)
+ *   - client_id: filtre client pour BT/BL (optionnel)
+ *   - client_name: filtre client pour BA/Soumission (optionnel)
  */
 export async function GET(request) {
   try {
     const { searchParams } = new URL(request.url);
     const type = searchParams.get('type');
     const search = (searchParams.get('search') || '').trim();
+    const clientId = searchParams.get('client_id');
+    const clientName = (searchParams.get('client_name') || '').trim();
 
     let items = [];
 
@@ -32,9 +49,11 @@ export async function GET(request) {
       let q = supabaseAdmin
         .from('work_orders')
         .select('id, bt_number, work_date, client:clients(name)')
+        .eq('status', 'draft')
         .order('created_at', { ascending: false })
         .limit(LIMIT);
       if (search) q = q.ilike('bt_number', `%${search}%`);
+      if (clientId) q = q.eq('client_id', clientId);
       const { data, error } = await q;
       if (error) throw error;
       items = (data || []).map((r) => ({
@@ -47,9 +66,11 @@ export async function GET(request) {
       let q = supabaseAdmin
         .from('delivery_notes')
         .select('id, bl_number, client_name, delivery_date')
+        .eq('status', 'draft')
         .order('created_at', { ascending: false })
         .limit(LIMIT);
       if (search) q = q.ilike('bl_number', `%${search}%`);
+      if (clientId) q = q.eq('client_id', clientId);
       const { data, error } = await q;
       if (error) throw error;
       items = (data || []).map((r) => ({
@@ -62,9 +83,11 @@ export async function GET(request) {
       let q = supabaseAdmin
         .from('purchase_orders')
         .select('id, po_number, client_name, created_at')
+        .eq('status', 'in_progress')
         .order('created_at', { ascending: false })
         .limit(LIMIT);
       if (search) q = q.ilike('po_number', `%${search}%`);
+      if (clientName) q = q.eq('client_name', clientName);
       const { data, error } = await q;
       if (error) throw error;
       items = (data || []).map((r) => ({
@@ -77,9 +100,11 @@ export async function GET(request) {
       let q = supabaseAdmin
         .from('submissions')
         .select('id, submission_number, client_name, created_at')
+        .in('status', ['sent', 'accepted'])
         .order('created_at', { ascending: false })
         .limit(LIMIT);
       if (search) q = q.ilike('submission_number', `%${search}%`);
+      if (clientName) q = q.eq('client_name', clientName);
       const { data, error } = await q;
       if (error) throw error;
       items = (data || []).map((r) => ({

--- a/app/api/notes/route.js
+++ b/app/api/notes/route.js
@@ -3,9 +3,10 @@
  * @description API CRUD pour le système de Notes.
  *              - GET: Liste les notes (filtres: completed, note_type, recherche)
  *              - POST: Crée une nouvelle note (globale ou liée à un projet)
- * @version 1.0.0
+ * @version 1.1.0
  * @date 2026-06-09
  * @changelog
+ *   1.1.0 - Support du client associé à une note (client_id, client_name)
  *   1.0.0 - Version initiale (Système de Notes MVP)
  */
 
@@ -86,6 +87,8 @@ export async function POST(request) {
       project_id = null,
       project_number = null,
       due_date = null,
+      client_id = null,
+      client_name = null,
       user_id = null,
     } = body;
 
@@ -131,6 +134,8 @@ export async function POST(request) {
         project_id: cleanProjectId,
         project_number: cleanProjectNumber,
         due_date: due_date || null,
+        client_id: client_id || null,
+        client_name: client_name ? String(client_name).trim() : null,
         user_id: user_id || null,
       })
       .select()

--- a/components/notes/NoteCard.js
+++ b/components/notes/NoteCard.js
@@ -4,17 +4,19 @@
  *              - Couleur de fond selon l'urgence (rouge/orange/gris)
  *              - Checkbox pour marquer complété (la note disparaît ensuite)
  *              - Badge projet cliquable (ouvre le SplitView: BT/BL/BA/Soumission)
+ *              - Badge client (si la note est associée à un client)
  *              - Boutons Éditer / Supprimer (suppression avec confirmation)
- * @version 1.0.0
+ * @version 1.1.0
  * @date 2026-06-09
  * @changelog
+ *   1.1.0 - Affichage du client associé à la note (badge)
  *   1.0.0 - Version initiale (Système de Notes MVP)
  */
 
 'use client';
 
 import React, { useState } from 'react';
-import { Check, Pencil, Trash2, Calendar, Loader2, StickyNote } from 'lucide-react';
+import { Check, Pencil, Trash2, Calendar, Loader2, StickyNote, User } from 'lucide-react';
 import ReferenceLink from '../SplitView/ReferenceLink';
 import {
   getUrgency,
@@ -99,6 +101,14 @@ export default function NoteCard({ note, onToggleComplete, onEdit, onDelete }) {
               <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium text-gray-500 dark:text-gray-400">
                 <Calendar className="w-3 h-3" />
                 Sans échéance
+              </span>
+            )}
+
+            {/* Badge client */}
+            {note.client_name && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300">
+                <User className="w-3 h-3" />
+                {note.client_name}
               </span>
             )}
 

--- a/components/notes/NoteForm.js
+++ b/components/notes/NoteForm.js
@@ -2,12 +2,15 @@
  * @file components/notes/NoteForm.js
  * @description Modal de création / édition d'une note.
  *              - Champs: Titre (requis), Description, Échéance (optionnelle),
- *                Type (Global / Lié à un projet), sélecteur de document si projet
+ *                Client (optionnel), Type (Global / Lié à un projet), sélecteur de document
+ *              - Le client (si choisi) filtre le sélecteur de document
  *              - Le sélecteur charge BT/BL/BA/Soumission via /api/notes/projects
+ *                (Brouillons BT/BL, BA En cours, Soumissions Envoyées/Acceptées)
  *              - Validation: titre min 3 caractères, document requis si type projet
- * @version 1.0.0
+ * @version 1.1.0
  * @date 2026-06-09
  * @changelog
+ *   1.1.0 - Ajout du sélecteur de client (optionnel) qui filtre les documents liables
  *   1.0.0 - Version initiale (Système de Notes MVP)
  */
 
@@ -30,18 +33,37 @@ export default function NoteForm({ note, onSave, onClose }) {
   const [title, setTitle] = useState(note?.title || '');
   const [description, setDescription] = useState(note?.description || '');
   const [dueDate, setDueDate] = useState(note?.due_date || '');
+  const [clientId, setClientId] = useState(note?.client_id || '');
+  const [clientName, setClientName] = useState(note?.client_name || '');
   const [noteType, setNoteType] = useState(note?.note_type || 'global');
   const [projectType, setProjectType] = useState(note?.project_type || 'work_order');
   const [projectId, setProjectId] = useState(note?.project_id || null);
   const [projectNumber, setProjectNumber] = useState(note?.project_number || '');
 
+  const [clients, setClients] = useState([]);
   const [docs, setDocs] = useState([]);
   const [docSearch, setDocSearch] = useState('');
   const [loadingDocs, setLoadingDocs] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
 
-  // Charger les documents quand on passe en mode projet ou qu'on change de type
+  // Charger la liste des clients (pour le sélecteur de client)
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/clients')
+      .then((res) => res.json())
+      .then((data) => {
+        if (!cancelled && Array.isArray(data)) setClients(data);
+      })
+      .catch(() => {
+        if (!cancelled) setClients([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Charger les documents quand on passe en mode projet ou qu'on change de type/client
   useEffect(() => {
     if (noteType !== 'project') return;
     let cancelled = false;
@@ -51,6 +73,9 @@ export default function NoteForm({ note, onSave, onClose }) {
       try {
         const params = new URLSearchParams({ type: projectType });
         if (docSearch.trim()) params.set('search', docSearch.trim());
+        // BT/BL filtrés par client_id, BA/Soumission par client_name
+        if (clientId) params.set('client_id', clientId);
+        if (clientName) params.set('client_name', clientName);
         const res = await fetch(`/api/notes/projects?${params.toString()}`);
         const json = await res.json();
         if (!cancelled && json.success) setDocs(json.data || []);
@@ -66,7 +91,17 @@ export default function NoteForm({ note, onSave, onClose }) {
       cancelled = true;
       clearTimeout(t);
     };
-  }, [noteType, projectType, docSearch]);
+  }, [noteType, projectType, docSearch, clientId, clientName]);
+
+  // Quand on change de client, réinitialiser le document sélectionné
+  const handleClientChange = (e) => {
+    const id = e.target.value;
+    setClientId(id);
+    const selected = clients.find((c) => String(c.id) === String(id));
+    setClientName(selected?.name || '');
+    setProjectId(null);
+    setProjectNumber('');
+  };
 
   const handleSelectDoc = (doc) => {
     setProjectId(doc.id);
@@ -89,6 +124,8 @@ export default function NoteForm({ note, onSave, onClose }) {
       title: title.trim(),
       description: description.trim() || null,
       due_date: dueDate || null,
+      client_id: clientId || null,
+      client_name: clientName || null,
       note_type: noteType,
       project_type: noteType === 'project' ? projectType : null,
       project_id: noteType === 'project' ? projectId : null,
@@ -170,6 +207,28 @@ export default function NoteForm({ note, onSave, onClose }) {
             />
             <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
               Sans date, la note reste en bas du tableau (fond gris).
+            </p>
+          </div>
+
+          {/* Client (optionnel) */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Client <span className="text-gray-400 font-normal">(optionnel)</span>
+            </label>
+            <select
+              value={clientId || ''}
+              onChange={handleClientChange}
+              className="w-full px-3 py-2.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            >
+              <option value="">— Aucun client —</option>
+              {clients.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+            <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+              Filtre les documents (BT/BL/BA/Soumission) liables à ce client.
             </p>
           </div>
 

--- a/components/notes/NotesManager.js
+++ b/components/notes/NotesManager.js
@@ -75,7 +75,8 @@ export default function NotesManager() {
       const inTitle = (n.title || '').toLowerCase().includes(q);
       const inDesc = (n.description || '').toLowerCase().includes(q);
       const inNumber = (n.project_number || '').toLowerCase().includes(q);
-      if (!inTitle && !inDesc && !inNumber) return false;
+      const inClient = (n.client_name || '').toLowerCase().includes(q);
+      if (!inTitle && !inDesc && !inNumber && !inClient) return false;
     }
     return true;
   });

--- a/supabase/migrations/20260609b_add_client_to_notes.sql
+++ b/supabase/migrations/20260609b_add_client_to_notes.sql
@@ -1,0 +1,13 @@
+-- ============================================
+-- Système de Notes — Ajout du client à une note
+-- Date: 2026-06-09
+-- Description: Permet d'associer un client à une note (optionnel). Le client
+--              sert aussi à filtrer le sélecteur de document (BT/BL/BA/Soumission)
+--              dans le formulaire de note. client_id est la référence officielle,
+--              client_name est conservé comme snapshot pour l'affichage.
+-- ============================================
+
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS client_id BIGINT REFERENCES clients(id);
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS client_name TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_notes_client_id ON notes(client_id);


### PR DESCRIPTION
- Ajout d'un client (optionnel) sur les notes (client_id + client_name)
- Le client sélectionné filtre le sélecteur de document (BT/BL par client_id, BA/Soumission par client_name)
- Le sélecteur n'affiche désormais que les documents pertinents: BT/BL en Brouillon, BA En cours, Soumissions Envoyée/Acceptée
- Badge client sur la carte de note + recherche par nom de client

https://claude.ai/code/session_01L5i4P76yJNGNYa8wziRdSm