### PR TITLE
Affichage quantité en commande (AF): inventaire + recherche BT/BL

### DIFF
--- a/components/InventoryManager.js
+++ b/components/InventoryManager.js
@@ -8,9 +8,13 @@
  *              - Badge visuel Inventaire vs Non-inventaire
  *              - En main (stock_qty), En commande (AF), Réservé (BT/BL)
  *              - Modal unifié : Édition + Historique mouvements + Historique prix
- * @version 3.8.0
- * @date 2026-04-21
+ * @version 3.9.0
+ * @date 2026-06-11
  * @changelog
+ *   3.9.0 - Rafraîchit les quantités En commande/Réservé à chaque chargement
+ *           (recherche, charger tout, charger par groupe) et plus seulement au
+ *           montage. Corrige l'affichage "+0 en commande" pour un AF créé après
+ *           l'ouverture de l'inventaire (la donnée serveur était correcte).
  *   3.8.0 - Calcul "En commande" + "Réservé" déplacé côté serveur via
  *           /api/inventory/reservations (supabaseAdmin) car la table
  *           work_order_materials a une RLS SELECT qui bloque les lectures
@@ -190,6 +194,7 @@ export default function InventoryManager() {
   const performSearch = async (term) => {
     try {
       setSearchLoading(true);
+      loadQuantities(); // Rafraîchir en commande/réservé (peut avoir changé depuis le montage)
       const response = await fetch(`/api/products/search?mode=search&search=${encodeURIComponent(term)}`);
       const result = await response.json();
 
@@ -215,6 +220,7 @@ export default function InventoryManager() {
     try {
       setLoading(true);
       setSearchTerm('');
+      loadQuantities(); // Rafraîchir en commande/réservé (peut avoir changé depuis le montage)
       const response = await fetch('/api/products/search?mode=all');
       const result = await response.json();
 
@@ -243,6 +249,7 @@ export default function InventoryManager() {
       setLoading(true);
       setSelectedLoadGroup(group);
       setSearchTerm('');
+      loadQuantities(); // Rafraîchir en commande/réservé (peut avoir changé depuis le montage)
       const response = await fetch(`/api/products/search?mode=group&group=${encodeURIComponent(group)}`);
       const result = await response.json();
 

--- a/components/work-orders/MaterialSelector.js
+++ b/components/work-orders/MaterialSelector.js
@@ -5,9 +5,12 @@
  *              - Ajout rapide de produits non-inventaire
  *              - Clavier numérique pour saisie quantités (optimisé tablette)
  *              - Affichage/masquage prix par article
- * @version 1.5.0
+ *              - Affichage stock en main + quantité en commande (AF) dans la recherche
+ * @version 1.6.0
  * @date 2026-06-11
  * @changelog
+ *   1.6.0 - Affiche la quantité "En commande" (AF ordered/partial) à côté du stock
+ *           dans les résultats de recherche, via /api/inventory/reservations.
  *   1.5.0 - Fix badge "Stock" périmé (BT+BL): rafraîchissement auto en arrière-plan à l'ouverture
  *           de la recherche (stale-while-revalidate) + invalidation du cache de filtrage au rechargement.
  *           Un item juste acheté affichait "Stock: 0" alors que l'inventaire montrait la bonne quantité.
@@ -144,7 +147,10 @@ export default function MaterialSelector({
   const [cachedProducts, setCachedProducts] = useState([]);
   const [lastFetchTime, setLastFetchTime] = useState(null);
   const [filteredCache, setFilteredCache] = useState({});
-  
+
+  // Quantités "En commande" (AF) par product_id, pour affichage dans la recherche
+  const [onOrderMap, setOnOrderMap] = useState({});
+
   // Modal d'édition complet
   const [editingMaterial, setEditingMaterial] = useState(null);
   const [editForm, setEditForm] = useState({
@@ -172,7 +178,26 @@ export default function MaterialSelector({
   // Chargement initial des produits avec cache
   useEffect(() => {
     loadProducts();
+    loadOnOrder();
   }, []);
+
+  // Charger les quantités "En commande" (AF ordered/partial) pour la recherche
+  const loadOnOrder = async () => {
+    try {
+      const response = await fetch('/api/inventory/reservations');
+      if (!response.ok) return;
+      const result = await response.json();
+      if (result.success && result.quantities) {
+        const map = {};
+        Object.entries(result.quantities).forEach(([pid, q]) => {
+          if (q && q.onOrder > 0) map[pid] = q.onOrder;
+        });
+        setOnOrderMap(map);
+      }
+    } catch (error) {
+      console.error('Erreur chargement quantités en commande:', error);
+    }
+  };
 
   // Filtrage produits (optimisé comme InventoryManager)
   useEffect(() => {
@@ -767,6 +792,11 @@ const deleteMaterialFromModal = () => {
                           <div className="flex gap-4 text-xs text-gray-600 dark:text-gray-400">
                             {product.unit && <span>Unité: {product.unit}</span>}
                             <span>Stock: {product.stock_qty || 0}</span>
+                            {(onOrderMap[product.product_id] > 0) && (
+                              <span className="text-blue-600 dark:text-blue-400 font-medium">
+                                En commande: +{onOrderMap[product.product_id]}
+                              </span>
+                            )}
                             {/* SUPPRIMÉ: Plus de coûts affichés dans la recherche */}
                           </div>
                         </div>


### PR DESCRIPTION
Inventaire: les quantités En commande/Réservé n'étaient chargées qu'au montage du composant. Un AF créé après l'ouverture de l'inventaire restait affiché à "+0" jusqu'au rechargement complet de la page, alors que la donnée serveur (/api/inventory/reservations) était correcte. Fix: rafraîchir loadQuantities() à chaque chargement d'items (recherche, charger tout, charger par groupe).

Recherche matériaux BT/BL: la quantité en commande n'était pas affichée
du tout (seul le stock en main). Fix: MaterialSelector charge
/api/inventory/reservations et affiche "En commande: +X" à côté du stock.

https://claude.ai/code/session_01KjSNtXQWpjPok7W5X9Aemx