### PR TITLE
Confirmation d'envoi explicite avec copie au bureau (états de compte …

### DIFF
--- a/app/api/invoices/[id]/send-email/route.js
+++ b/app/api/invoices/[id]/send-email/route.js
@@ -6,9 +6,10 @@
  *              - Sauvegarde pdf_url dans la table invoices
  *              - Envoie par Resend au client (cascade email)
  *              - Met à jour le statut de la facture à 'sent'
- * @version 1.4.0
- * @date 2026-06-04
+ * @version 1.5.0
+ * @date 2026-06-14
  * @changelog
+ *   1.5.0 - Message de confirmation explicite incluant la copie au bureau (CC COMPANY_EMAIL)
  *   1.4.0 - Ajout avis no-reply Resend (sous "N'hésitez pas à nous contacter")
  *           + lien de contact cliquable (mailto) dans le pied de page du courriel
  *   1.3.0 - Ajout mode print_only: génère PDF + upload Storage + marque envoyée
@@ -431,10 +432,12 @@ export async function POST(request, { params }) {
       });
     }
 
+    const ccNote = process.env.COMPANY_EMAIL ? ` (copie au bureau: ${process.env.COMPANY_EMAIL})` : '';
     return NextResponse.json({
       success: true,
-      message: `Facture ${invoice.invoice_number} envoyée à ${emailAddresses.join(', ')}`,
+      message: `Facture ${invoice.invoice_number} envoyée à ${emailAddresses.join(', ')}${ccNote}`,
       sentTo: emailAddresses,
+      cc: process.env.COMPANY_EMAIL || null,
     });
 
   } catch (error) {

--- a/app/api/statements/[clientId]/send-email/route.js
+++ b/app/api/statements/[clientId]/send-email/route.js
@@ -6,9 +6,10 @@
  *              - Upload dans Supabase Storage (bucket 'invoices', préfixe statements/)
  *              - print_only: retourne l'URL du PDF sans envoyer de courriel (aperçu)
  *              - Sinon envoie via Resend aux adresses sélectionnées (cascade email_billing)
- * @version 1.0.0
+ * @version 1.1.0
  * @date 2026-06-14
  * @changelog
+ *   1.1.0 - Message de confirmation explicite incluant la copie au bureau (CC COMPANY_EMAIL)
  *   1.0.0 - Version initiale (module État de compte client)
  */
 
@@ -463,10 +464,12 @@ export async function POST(request, { params }) {
       });
     }
 
+    const ccNote = process.env.COMPANY_EMAIL ? ` (copie au bureau: ${process.env.COMPANY_EMAIL})` : '';
     return NextResponse.json({
       success: true,
-      message: `État de compte envoyé à ${emailAddresses.join(', ')}`,
+      message: `État de compte envoyé à ${emailAddresses.join(', ')}${ccNote}`,
       sentTo: emailAddresses,
+      cc: process.env.COMPANY_EMAIL || null,
       pdf_url: pdfUrl,
     });
   } catch (error) {


### PR DESCRIPTION
…+ factures)

Le message de succès indique désormais la copie CC envoyée au COMPANY_EMAIL, comme preuve d'envoi visible dans l'app.

https://claude.ai/code/session_017YGHiYdhAnfuKxQmEFfr63