### PR TITLE
Rapport quotidien achats: retirer le bureau des destinataires

### DIFF
--- a/app/api/send-daily-report/route.js
+++ b/app/api/send-daily-report/route.js
@@ -318,11 +318,11 @@ async function sendDailyReport() {
 
     // Envoyer l'email avec le domaine vérifié
     console.log('📧 Envoi email depuis: noreply@servicestmt.ca');
-    console.log('📧 Destinataires:', ['servicestmt@gmail.com', 'info.servicestmt@gmail.com']);
-    
+    console.log('📧 Destinataires:', ['servicestmt@gmail.com']);
+
     const { data, error: resendError } = await resend.emails.send({
       from: 'Système TMT <noreply@servicestmt.ca>',
-      to: ['servicestmt@gmail.com', 'info.servicestmt@gmail.com'],
+      to: ['servicestmt@gmail.com'],
       subject: `📋 Rapport quotidien - ${purchases?.length || 0} achat(s) en cours`,
       html: emailHtml,
       reply_to: 'info.servicestmt@gmail.com',


### PR DESCRIPTION
Le rapport quotidien des achats fournisseurs n'est plus envoyé à info.servicestmt@gmail.com (bureau), seulement à servicestmt@gmail.com. L'adresse du bureau reste en reply_to.


Claude-Session: https://claude.ai/code/session_01FiwK8wtasY3mn1MJnnUbLp