### PR TITLE
BT: bloquer la présentation client tant qu'une session de temps est e…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -777,6 +777,9 @@ CRON_SECRET                   # Auth pour cron jobs
 9. **Ajustements visuels Dark Mode** - Tester sur tablette, corriger couleurs si besoin
 
 ### Bugs connus (corrigés)
+- ~~BT sans total (0h) sur le PDF client quand le chrono n'est pas arrêté~~ → Corrigé (2026-07-15)
+  - Symptôme: session non arrêtée (chrono oublié) → à la signature, le PDF affichait les heures travaillées (ex. `08:22-11:35`) mais le total tombait à `0h` (par ligne + grand total), car la session était enregistrée avec une heure de fin mais `total_hours: 0`. Le rattrapage à la signature (`complete-signature`, auto-terminaison des sessions `in_progress`) ne couvrait pas tous les cas.
+  - Correctif à la source: `WorkOrderForm.js` v1.5.0 — la présentation client (« Présenter au client » → `ready_for_signature`) est **bloquée** tant que le chronomètre tourne (`trackerIsWorking`). L'utilisateur doit appuyer sur « Terminer » d'abord (fige l'heure de fin, calcule le total, permet de vérifier les cases Retour/Transport). Aucune migration requise.
 - ~~Pull-to-refresh natif perd les données en cours (BT/BL/Facture) sur mobile/tablette~~ → Corrigé (2026-06-22)
   - `components/DisablePullToRefresh.js` (nouveau) — Composant qui applique `overscroll-behavior-y: contain` sur `<html>`/`<body>` **uniquement** pendant qu'un formulaire de saisie est monté, puis restaure la valeur au démontage. Monté dans `WorkOrderForm.js` (v1.4.0), `DeliveryNoteForm.js` (v3.4.0) et `InvoiceEditor.js` (v2.8.0).
   - **Ciblé volontairement** : le pull-to-refresh reste actif sur les pages de liste (BT/BL) où il sert à voir un document punché depuis un autre appareil. Une règle globale `html, body` casserait ce besoin.

--- a/RECOMMANDATIONS.md
+++ b/RECOMMANDATIONS.md
@@ -1590,4 +1590,32 @@ Le rapport annuel utilise l'année civile (1er janv. → 31 déc.).
 
 ---
 
-*Document genere le 2026-02-05, mis a jour le 2026-07-14 par Claude AI*
+## BT — Blocage présentation client si session de temps en cours ✅ COMPLETE (2026-07-15)
+
+**Problème signalé (Martin):** Quand une session de travail n'était pas arrêtée
+(chrono oublié) et que le client signait, le PDF affichait bien les heures
+travaillées (ex. `08:22-11:35`) mais le **total tombait à 0h** — par ligne ET au
+grand total.
+
+**Cause:** Le rattrapage à la signature (`complete-signature`, auto-terminaison
+de la session `in_progress`) ne couvre pas tous les cas : une session pouvait être
+enregistrée avec une heure de fin mais `total_hours: 0`, donc le PDF (qui lit
+`entry.total_hours`) affichait `0h`.
+
+**Correctif (à la source):** On empêche désormais de présenter le BT au client
+(« Présenter au client » → statut `ready_for_signature`) tant que le chronomètre
+tourne. L'utilisateur doit d'abord appuyer sur « Terminer » — ce qui fige l'heure
+de fin, calcule le total, ET permet de vérifier les cases Retour/Transport de la
+session avant présentation.
+
+**Implémentation complétée (2026-07-15):**
+- `components/work-orders/WorkOrderForm.js` v1.5.0 — garde-fou dans `handleSubmit`:
+  si `status === 'ready_for_signature'` et que le TimeTracker signale une session
+  active (`trackerIsWorking`), on bloque avec un message explicite et on ne
+  sauvegarde pas. Couvre les deux boutons « Présenter au client » (haut + bas).
+
+**Aucune migration SQL requise.**
+
+---
+
+*Document genere le 2026-02-05, mis a jour le 2026-07-15 par Claude AI*

--- a/components/work-orders/WorkOrderForm.js
+++ b/components/work-orders/WorkOrderForm.js
@@ -5,9 +5,10 @@
  *              - Intégration TimeTracker (suivi temps) et MaterialSelector (matériaux)
  *              - Import depuis soumissions et achats fournisseurs
  *              - Gestion emails et workflow signature client
- * @version 1.4.0
- * @date 2026-06-22
+ * @version 1.5.0
+ * @date 2026-07-15
  * @changelog
+ *   1.5.0 - Bloque la présentation client (« Présenter au client ») tant qu'une session de temps est en cours. Évite qu'une session soit envoyée au client sans total (0h). L'utilisateur doit d'abord appuyer sur « Terminer » (et vérifier les cases Retour/Transport).
  *   1.4.0 - Désactive le pull-to-refresh natif pendant la saisie (DisablePullToRefresh) pour éviter la perte de données sur mobile/tablette
  *   1.3.1 - Saisie manuelle du BA Client forcée en MAJUSCULES (CSS textTransform + onBlur, autoCapitalize="characters" pour clavier mobile)
  *   1.3.0 - UX mobile: bouton "Commencer nouvelle session" déplacé entre la section BA et la Date de travail. Checkbox Prix Jobé déplacée sous le TimeTracker. Sessions affichées en ordre inversé dans le formulaire (dernière en haut, via TimeTracker v2.3.0)
@@ -1106,6 +1107,21 @@ const getFilteredSupplierPurchases = () => {
     // ✅ PROTECTION: Empêcher double soumission
     if (isSubmitting) {
       console.log('⏸️ Soumission déjà en cours, ignorée');
+      return;
+    }
+
+    // ⏱️ BLOCAGE: Empêcher la présentation client si une session de temps est
+    // encore en cours (chrono non arrêté). Sinon la session est enregistrée sans
+    // total (0h) → le PDF client affiche les heures mais pas le total.
+    // L'utilisateur doit d'abord appuyer sur « Terminer » pour figer l'heure de
+    // fin ET pouvoir vérifier les cases Retour/Transport de la session.
+    if (status === 'ready_for_signature' && trackerIsWorking) {
+      alert(
+        '⏱️ Session de travail en cours!\n\n' +
+        'Le chronomètre est toujours démarré. Appuyez sur « Terminer » dans le ' +
+        'Suivi du temps pour arrêter la session, puis vérifiez les cases ' +
+        'Retour / Transport avant de présenter le BT au client.'
+      );
       return;
     }
 


### PR DESCRIPTION
…n cours

Quand le chrono d'une session n'était pas arrêté, la session était enregistrée avec une heure de fin mais total_hours: 0. À la signature, le PDF client affichait les heures travaillées mais un total à 0h (par ligne et au grand total).

Correctif à la source dans WorkOrderForm.handleSubmit: la présentation client (ready_for_signature) est bloquée tant que le TimeTracker signale une session active (trackerIsWorking). L'utilisateur doit appuyer sur « Terminer » d'abord, ce qui fige l'heure de fin, calcule le total et permet de vérifier les cases Retour/Transport de la session.

- WorkOrderForm.js v1.5.0
- Doc: RECOMMANDATIONS.md + CLAUDE.md (Bugs connus)


Claude-Session: https://claude.ai/code/session_01GoT2XtVvp44Yq1Usk56UKM