### PR TITLE
À Commander: ajouter « En commande » (qté sur AF actifs) à la ligne d…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,7 +408,7 @@ const total = subtotal + tps + tvq;
 /api/products/search                   → Recherche serveur inventaire (modes: search, all, group)
 /api/products/groups                   → Groupes de produits distincts
 /api/inventory/reservations            → En commande (AF) + Réservé (BT/BL non signés) + détail par doc
-/api/items-to-order                    → Liste À Commander (GET par statut, enrichi inventaire vivant qté/coûtant/vendant + POST ajout enrichi/fusion)
+/api/items-to-order                    → Liste À Commander (GET par statut, enrichi inventaire vivant qté/en commande/coûtant/vendant + POST ajout enrichi/fusion)
 /api/items-to-order/[id]               → GET/PUT/DELETE item à commander
 /api/items-to-order/mark-ordered       → Marque un lot commandé + lie l'AF (après création AF)
 /api/statistics                        → Rapports & Statistiques de ventes (GET avec filtres)

--- a/app/api/items-to-order/route.js
+++ b/app/api/items-to-order/route.js
@@ -7,9 +7,11 @@
  *                table products/non_inventory_items (les lignes BT/BL/Soum. ne portent
  *                pas ces champs). Fusionne les doublons en attente (même code produit)
  *                en additionnant les quantités.
- * @version 1.1.0
+ * @version 1.2.0
  * @date 2026-08-06
  * @changelog
+ *   1.2.0 - Ajout « En commande » (inv_on_order): quantité sur les AF actifs
+ *           (ordered/partial), même logique que /api/inventory/reservations.
  *   1.1.0 - GET enrichit chaque item avec l'inventaire vivant (qté en main + coûtant
  *           + vendant) depuis products/non_inventory_items (inv_stock_qty,
  *           inv_cost_price, inv_selling_price, inv_is_non_inventory).
@@ -100,7 +102,8 @@ export async function GET(request) {
     ];
 
     if (codes.length > 0) {
-      const [prodRes, nonInvRes] = await Promise.all([
+      const codeSet = new Set(codes);
+      const [prodRes, nonInvRes, afRes] = await Promise.all([
         supabaseAdmin
           .from('products')
           .select('product_id, stock_qty, cost_price, selling_price')
@@ -109,7 +112,25 @@ export async function GET(request) {
           .from('non_inventory_items')
           .select('product_id, cost_price, selling_price')
           .in('product_id', codes),
+        // « En commande »: quantités sur les AF actifs (ordered/partial), items en JSONB.
+        // Même logique que /api/inventory/reservations (clé = product_id || product_code).
+        supabaseAdmin
+          .from('supplier_purchases')
+          .select('items, status')
+          .in('status', ['ordered', 'partial']),
       ]);
+
+      // Somme « en commande » par code produit (uniquement les codes de notre liste).
+      const onOrderMap = new Map();
+      (afRes.data || []).forEach((purchase) => {
+        (purchase.items || []).forEach((item) => {
+          const raw = item.product_id || item.product_code;
+          if (raw == null) return;
+          const key = String(raw).trim();
+          if (!codeSet.has(key)) return;
+          onOrderMap.set(key, (onOrderMap.get(key) || 0) + (parseFloat(item.quantity) || 0));
+        });
+      });
 
       const invMap = new Map();
       (prodRes.data || []).forEach((p) => {
@@ -134,12 +155,14 @@ export async function GET(request) {
       });
 
       items.forEach((it) => {
-        const info = it.product_code ? invMap.get(String(it.product_code).trim()) : null;
+        const key = it.product_code ? String(it.product_code).trim() : null;
+        const info = key ? invMap.get(key) : null;
         it.inv_stock_qty = info ? info.stock_qty : null;
         it.inv_cost_price =
           info && info.cost_price != null ? info.cost_price : it.cost_price;
         it.inv_selling_price = info ? info.selling_price : null;
         it.inv_is_non_inventory = info ? info.is_non_inventory : null;
+        it.inv_on_order = key && onOrderMap.has(key) ? onOrderMap.get(key) : 0;
       });
     }
 

--- a/components/order-list/OrderListManager.js
+++ b/components/order-list/OrderListManager.js
@@ -9,9 +9,10 @@
  *                sessionStorage ('af-prefill') puis bascule vers l'onglet Achats
  *                Fournisseurs (le hook AF pré-remplit le formulaire au montage).
  *              - Mobile/tablette: touch targets 44px, cartes empilées.
- * @version 1.1.0
+ * @version 1.2.0
  * @date 2026-08-06
  * @changelog
+ *   1.2.0 - Ajout « En commande » (qté sur AF actifs) entre En main et Coûtant.
  *   1.1.0 - Ligne d'info inventaire vivant (En main / Coûtant / Vendant) sur chaque
  *           item en attente; libellé « Qté » → « À commander ».
  *   1.0.0 - Version initiale (Liste À Commander MVP)
@@ -408,6 +409,18 @@ export default function OrderListManager({ onCreateAF, onCountChange }) {
                               }`}
                             >
                               {formatStock(it.inv_stock_qty)}
+                            </span>
+                          </span>
+                          <span className="text-gray-500 dark:text-gray-400">
+                            En commande :{' '}
+                            <span
+                              className={`font-semibold ${
+                                parseFloat(it.inv_on_order) > 0
+                                  ? 'text-blue-700 dark:text-blue-300'
+                                  : 'text-gray-900 dark:text-gray-100'
+                              }`}
+                            >
+                              {formatStock(it.inv_on_order)}
                             </span>
                           </span>
                           <span className="text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
…'info

Affiche maintenant: En main · En commande · Coûtant · Vendant. « En commande » = somme des quantités sur les AF actifs (statut ordered/partial), même logique que /api/inventory/reservations. Valeur en bleu quand > 0.

- app/api/items-to-order/route.js v1.2.0: calcul inv_on_order depuis supplier_purchases (items JSONB, statuts ordered/partial)
- components/order-list/OrderListManager.js v1.2.0: affichage « En commande » entre En main et Coûtant

Aucune migration requise.


Claude-Session: https://claude.ai/code/session_01EeEKvTt3cpt3qNDVEpq269