### PR TITLE
AF: ajout champ « Client » (remplace « BA Acomba »)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -835,6 +835,14 @@ CRON_SECRET                   # Auth pour cron jobs
     - Décisions: liste globale, tap direct, fournisseur suggéré changeable (groupe « À assigner »), apprentissage dernier fournisseur, badge compteur (pas de clignotant), vue Commandés (historique + lien AF)
     - **Reste:** exécuter la migration SQL `20260721_create_items_to_order.sql` dans Supabase Dashboard
 
+25. ~~**AF: champ « Client » (remplace « BA Acomba »)**~~ - ✅ COMPLÉTÉ (2026-08-06)
+    - `supabase/migrations/20260806_add_client_to_supplier_purchases.sql` (nouveau) — colonnes `client_id` + `client_name` sur `supplier_purchases` (référence souple, sans FK)
+    - `components/SupplierPurchaseServices.js` v2.3.0 — `fetchClients()` + en-tête PDF « Client » au lieu de « BA Acomba »
+    - `components/SupplierPurchaseHooks.js` — chargement clients, `client_id`/`client_name` (formulaire + 2 chemins de sauvegarde), recherche par client
+    - `components/SupplierPurchaseForms.js` v1.5.0 — `LinkedPOSection`: sélecteur « Ou Client » (auto-rempli depuis le BA lié); retrait du champ « BA Acomba »
+    - `components/SupplierPurchaseManager.js` v1.1.0 — colonne « Client » (desktop + mobile) au lieu de « BA Acomba »
+    - Note: `ba_acomba` conservé en base (rétrocompat), retiré de l'UI. **Reste:** exécuter la migration SQL dans Supabase Dashboard
+
 ### À faire (priorité utilisateur)
 6. **Statut soumissions** - Import partiel + changement auto "Acceptée" + ref croisée BA
 7. **Bandeau alertes** - BA orphelins / AF reçus sans livraison (reste Phase 3)

--- a/RECOMMANDATIONS.md
+++ b/RECOMMANDATIONS.md
@@ -1675,4 +1675,28 @@ Dashboard (sinon les appels à la liste échouent: table manquante).
 
 ---
 
-*Document genere le 2026-02-05, mis a jour le 2026-07-21 par Claude AI*
+### Achat Fournisseur (AF): champ « Client » (remplace « BA Acomba ») ✅ COMPLETE (2026-08-06)
+
+Dans le cadre « Bon d'achat client lié » du formulaire AF, ajout d'un sélecteur
+**« Ou Client »** permettant d'associer un client à l'AF même lorsqu'aucun BA client
+n'est lié (« pour qui » la commande est passée). Le champ **« BA Acomba »** est retiré
+du formulaire et remplacé par **« Client »** dans la liste (desktop + mobile) et le PDF.
+
+- `supabase/migrations/20260806_add_client_to_supplier_purchases.sql` (nouveau) — colonnes
+  `client_id` (BIGINT) + `client_name` (TEXT) sur `supplier_purchases` (référence souple, sans FK).
+- `components/SupplierPurchaseServices.js` v2.3.0 — `fetchClients()` (liste id/nom/compagnie);
+  en-tête PDF affiche « Client » au lieu de « BA Acomba ».
+- `components/SupplierPurchaseHooks.js` — chargement des clients, `client_id`/`client_name`
+  dans le formulaire + les 2 chemins de sauvegarde; recherche par client (au lieu de BA Acomba).
+- `components/SupplierPurchaseForms.js` v1.5.0 — `LinkedPOSection`: sélecteur « Ou Client »
+  (auto-rempli depuis le BA lié); retrait du champ « BA Acomba » (grille 4→3 colonnes).
+- `components/SupplierPurchaseManager.js` v1.1.0 — colonne « Client » (desktop + mobile) au lieu
+  de « BA Acomba »; recherche par client; passe `clients` au formulaire.
+
+**Note:** `ba_acomba` conservé en base et dans le payload (rétrocompatibilité), simplement retiré
+de l'UI. **Reste:** exécuter la migration SQL `20260806_add_client_to_supplier_purchases.sql`
+dans Supabase Dashboard (sinon la sauvegarde d'un AF échoue: colonnes manquantes).
+
+---
+
+*Document genere le 2026-02-05, mis a jour le 2026-08-06 par Claude AI*

--- a/components/SupplierPurchaseForms.js
+++ b/components/SupplierPurchaseForms.js
@@ -9,9 +9,11 @@
  *              - PriceUpdateModal: modal mise à jour prix
  *              - SupplierFormModal: formulaire fournisseur (dialog)
  *              - QuickSupplierModal: formulaire rapide fournisseur
- * @version 1.4.0
- * @date 2026-07-13
+ * @version 1.5.0
+ * @date 2026-08-06
  * @changelog
+ *   1.5.0 - Cadre « Bon d'achat client lié »: ajout d'un sélecteur « Ou Client » (client associé
+ *           même sans BA, auto-rempli depuis le BA lié). Retrait du champ « BA Acomba » du formulaire.
  *   1.4.0 - Fournisseurs: ajout d'un 2e et 3e contact (nom + email + téléphone optionnel)
  *           dans SupplierFormModal + affichage dans la liste. Dans le formulaire d'AF,
  *           sélecteur de destinataire(s) courriel (cases à cocher: contact principal + #2 + #3)
@@ -77,6 +79,7 @@ export const PurchaseForm = ({
   suppliers,
   shippingAddresses,
   purchaseOrders,
+  clients,
   selectedItems,
   setSelectedItems,
   editingPurchase,
@@ -545,28 +548,13 @@ Merci!`;
                   purchaseForm={purchaseForm}
                   setPurchaseForm={setPurchaseForm}
                   purchaseOrders={purchaseOrders}
+                  clients={clients}
                   suppliers={suppliers}
                 />
               </div>
 
-              {/* NOUVEAU - BA Acomba et Soumission fournisseur */}
-              <div className="grid grid-cols-1 lg:grid-cols-4 gap-4 sm:gap-6">
-                <div className="bg-purple-50 dark:bg-purple-900/20 p-4 rounded-lg border border-purple-200 dark:border-purple-700">
-                  <label className="block text-sm font-semibold text-purple-800 dark:text-purple-300 mb-2">
-                    BA Acomba
-                  </label>
-                  <input
-                    type="text"
-                    value={purchaseForm.ba_acomba}
-                    onChange={(e) => setPurchaseForm({...purchaseForm, ba_acomba: e.target.value})}
-                    className="block w-full rounded-lg border-purple-300 dark:border-purple-700 dark:bg-gray-800 dark:text-gray-100 shadow-sm focus:border-purple-500 focus:ring-purple-500 text-base p-3"
-                    placeholder="BA Acomba..."
-                    autoCorrect="off"
-                    autoCapitalize="off"
-                    spellCheck={false}
-                  />
-                </div>
-
+              {/* Soumission fournisseur + Date livraison + Statut */}
+              <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 sm:gap-6">
                 <div className="bg-yellow-50 dark:bg-yellow-900/20 p-4 rounded-lg border border-yellow-200 dark:border-yellow-700">
                   <label className="block text-sm font-semibold text-yellow-800 dark:text-yellow-300 mb-2">
                     Soumission
@@ -2265,7 +2253,7 @@ export const SupplierFormSimpleModal = ({
 };
 
 // ===== SECTION BA LIÉ AVEC BOUTON +BA ET LIEN CLIQUABLE =====
-const LinkedPOSection = ({ purchaseForm, setPurchaseForm, purchaseOrders, suppliers }) => {
+const LinkedPOSection = ({ purchaseForm, setPurchaseForm, purchaseOrders, clients = [], suppliers }) => {
   let splitView;
   try {
     splitView = useSplitView();
@@ -2320,6 +2308,10 @@ const LinkedPOSection = ({ purchaseForm, setPurchaseForm, purchaseOrders, suppli
               ...purchaseForm,
               linked_po_id: selectedPoId,
               linked_po_number: po?.po_number || '',
+              // Auto-remplir le client depuis le BA sélectionné (si présent)
+              ...(po
+                ? { client_id: po.client_id || '', client_name: po.client_name || '' }
+                : {}),
             });
           }}
           className="block w-full rounded-lg border-green-300 dark:border-green-700 dark:bg-gray-800 dark:text-gray-100 shadow-sm focus:border-green-500 focus:ring-green-500 text-base p-3"
@@ -2354,6 +2346,39 @@ const LinkedPOSection = ({ purchaseForm, setPurchaseForm, purchaseOrders, suppli
           >
             +BA
           </button>
+        )}
+      </div>
+
+      {/* Ou Client — pour savoir pour qui la commande est passée, même sans BA */}
+      <div className="mt-3">
+        <label className="block text-sm font-semibold text-green-800 dark:text-green-300 mb-2">
+          Ou Client (si aucun BA)
+        </label>
+        <select
+          value={purchaseForm.client_id || ''}
+          onChange={(e) => {
+            const selectedClientId = e.target.value;
+            const client = clients.find(c => String(c.id) === String(selectedClientId));
+            setPurchaseForm({
+              ...purchaseForm,
+              client_id: selectedClientId,
+              client_name: client?.name || '',
+            });
+          }}
+          className="block w-full rounded-lg border-green-300 dark:border-green-700 dark:bg-gray-800 dark:text-gray-100 shadow-sm focus:border-green-500 focus:ring-green-500 text-base p-3"
+        >
+          <option value="">Aucun (optionnel)</option>
+          {clients.map((client) => (
+            <option key={client.id} value={client.id}>
+              {client.name}{client.company ? ` (${client.company})` : ''}
+            </option>
+          ))}
+        </select>
+        {/* Repli: client hérité d'un BA lié sans correspondance dans la liste */}
+        {!purchaseForm.client_id && purchaseForm.client_name && (
+          <p className="text-xs text-green-700 dark:text-green-400 mt-1">
+            Client : {purchaseForm.client_name}
+          </p>
         )}
       </div>
     </div>

--- a/components/SupplierPurchaseHooks.js
+++ b/components/SupplierPurchaseHooks.js
@@ -6,6 +6,7 @@ import {
   fetchSuppliers,
   fetchPurchaseOrders,
   fetchShippingAddresses,
+  fetchClients,
   createSupplierPurchase,
   updateSupplierPurchase,
   deleteSupplierPurchase,
@@ -35,6 +36,7 @@ export const useSupplierPurchase = () => {
   const [supplierPurchases, setSupplierPurchases] = useState([]);
   const [suppliers, setSuppliers] = useState([]);
   const [purchaseOrders, setPurchaseOrders] = useState([]);
+  const [clients, setClients] = useState([]);
   const [shippingAddresses, setShippingAddresses] = useState([]);
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -90,7 +92,9 @@ export const useSupplierPurchase = () => {
     linked_po_number: '',
     linked_submission_id: null,
     supplier_quote_reference: '',
-    ba_acomba: '', // NOUVEAU CHAMP
+    ba_acomba: '', // Conservé pour compatibilité (champ retiré de l'UI)
+    client_id: '',      // Client associé (même sans BA lié)
+    client_name: '',    // Nom du client (affichage/liste/PDF)
     shipping_address_id: '',
     shipping_company: '',
     shipping_account: '',
@@ -396,6 +400,7 @@ const [priceUpdateForm, setPriceUpdateForm] = useState({
         loadSupplierPurchases(),
         loadSuppliers(),
         loadPurchaseOrders(),
+        loadClients(),
         loadShippingAddresses()
       ]);
     } catch (error) {
@@ -429,6 +434,15 @@ const [priceUpdateForm, setPriceUpdateForm] = useState({
       setPurchaseOrders(data);
     } catch (error) {
       console.error('Erreur chargement bons achat:', error);
+    }
+  };
+
+  const loadClients = async () => {
+    try {
+      const data = await fetchClients();
+      setClients(data);
+    } catch (error) {
+      console.error('Erreur chargement clients:', error);
     }
   };
 
@@ -898,7 +912,9 @@ const [priceUpdateForm, setPriceUpdateForm] = useState({
         linked_po_number: purchaseForm.linked_po_number,
         linked_submission_id: purchaseForm.linked_submission_id || null,
         supplier_quote_reference: purchaseForm.supplier_quote_reference,
-        ba_acomba: purchaseForm.ba_acomba, // NOUVEAU CHAMP
+        ba_acomba: purchaseForm.ba_acomba, // Conservé pour compatibilité (champ retiré de l'UI)
+        client_id: purchaseForm.client_id || null,
+        client_name: purchaseForm.client_name || '',
         shipping_address_id: purchaseForm.shipping_address_id,
         shipping_company: purchaseForm.shipping_company,
         shipping_account: purchaseForm.shipping_account,
@@ -981,6 +997,8 @@ const [priceUpdateForm, setPriceUpdateForm] = useState({
         linked_submission_id: purchaseForm.linked_submission_id || null,
         supplier_quote_reference: purchaseForm.supplier_quote_reference,
         ba_acomba: purchaseForm.ba_acomba,
+        client_id: purchaseForm.client_id || null,
+        client_name: purchaseForm.client_name || '',
         shipping_address_id: purchaseForm.shipping_address_id,
         shipping_company: purchaseForm.shipping_company,
         shipping_account: purchaseForm.shipping_account,
@@ -1183,7 +1201,9 @@ const [priceUpdateForm, setPriceUpdateForm] = useState({
       linked_po_number: '',
       linked_submission_id: null,
       supplier_quote_reference: '',
-      ba_acomba: '', // NOUVEAU CHAMP
+      ba_acomba: '', // Conservé pour compatibilité (champ retiré de l'UI)
+      client_id: '',
+      client_name: '',
       shipping_address_id: '',
       shipping_company: '',
       shipping_account: '',
@@ -1295,7 +1315,8 @@ const [priceUpdateForm, setPriceUpdateForm] = useState({
       purchase.purchase_number?.toLowerCase().includes(searchTerm.toLowerCase()) ||
       purchase.supplier_name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
       purchase.linked_po_number?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      purchase.ba_acomba?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      purchase.client_name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      purchase.linked_client_name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
       getPONumber(purchase, purchaseOrders)?.toLowerCase().includes(searchTerm.toLowerCase());
     
     const matchesStatus = statusFilter === 'all' || purchase.status === statusFilter;
@@ -1348,6 +1369,7 @@ const [priceUpdateForm, setPriceUpdateForm] = useState({
     supplierPurchases,
     suppliers,
     purchaseOrders,
+    clients,
     shippingAddresses,
     products,
     loading,

--- a/components/SupplierPurchaseManager.js
+++ b/components/SupplierPurchaseManager.js
@@ -4,9 +4,10 @@
  *              - Liste, création, modification, suppression des AF
  *              - Réception directe et réception AF
  *              - Gestion des adresses de livraison fournisseur
- * @version 1.0.2
- * @date 2026-03-07
+ * @version 1.1.0
+ * @date 2026-08-06
  * @changelog
+ *   1.1.0 - Colonne « BA Acomba » remplacée par « Client » (liste desktop + mobile), recherche par client
  *   1.0.2 - Fix curseur qui saute à la fin lors de la saisie dans les champs avec toUpperCase (CSS textTransform + onBlur)
  *   1.0.1 - Ajout attributs autoCorrect/autoCapitalize/spellCheck sur tous les champs texte
  *   1.0.0 - Version initiale
@@ -44,6 +45,7 @@ export default function SupplierPurchaseManager() {
     supplierPurchases,
     suppliers,
     purchaseOrders,
+    clients,
     shippingAddresses,
     loading,
     
@@ -185,6 +187,13 @@ export default function SupplierPurchaseManager() {
   setShowReceiptModal(true);
 };
   
+  // Nom du client d'un AF: client saisi directement, sinon hérité du BA lié
+  const getClientLabel = (purchase) =>
+    purchase.client_name ||
+    purchase.linked_client_name ||
+    purchase.purchase_orders?.client_name ||
+    '';
+
   // Loading state
   if (loading) {
     return (
@@ -206,6 +215,7 @@ export default function SupplierPurchaseManager() {
           suppliers={suppliers}
           shippingAddresses={shippingAddresses}
           purchaseOrders={purchaseOrders}
+          clients={clients}
           selectedItems={selectedItems}
           setSelectedItems={setSelectedItems}
           editingPurchase={editingPurchase}
@@ -487,7 +497,7 @@ export default function SupplierPurchaseManager() {
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
                 <input
                   type="text"
-                  placeholder="Rechercher par numéro, fournisseur, BA Acomba..."
+                  placeholder="Rechercher par numéro, fournisseur, client..."
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   className="block w-full pl-10 pr-4 py-3 rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 shadow-sm focus:border-orange-500 focus:ring-orange-500 text-base"
@@ -595,7 +605,7 @@ export default function SupplierPurchaseManager() {
               <tr>
                 <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">N° Achat</th>
                 <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Date Création</th>
-                <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">BA Acomba</th>
+                <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Client</th>
                 <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">PO Client Lié</th>
                 <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Fournisseur</th>
                 <th className="px-3 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Date Livraison</th>
@@ -628,10 +638,10 @@ export default function SupplierPurchaseManager() {
                         </div>
                       </div>
                     </td>
-                    <td className="px-3 py-4 whitespace-nowrap">
-                      {purchase.ba_acomba ? (
-                        <span className="bg-purple-100 text-purple-800 px-2 py-1 rounded text-xs">
-                          {purchase.ba_acomba}
+                    <td className="px-3 py-4">
+                      {getClientLabel(purchase) ? (
+                        <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                          {getClientLabel(purchase)}
                         </span>
                       ) : (
                         <span className="text-gray-400">-</span>
@@ -825,15 +835,17 @@ export default function SupplierPurchaseManager() {
                     </div>
                   </div>
 
-                  {/* LIGNE 2: BA Acomba + PO Client */}
+                  {/* LIGNE 2: Client + PO Client */}
                   <div className="flex items-center justify-between gap-2 text-xs text-gray-600 pl-2">
                     <div className="flex items-center gap-2 truncate flex-1 min-w-0" onClick={(e) => e.stopPropagation()}>
-                      {purchase.ba_acomba && (
-                        <span className="text-purple-600 font-medium">BA: {purchase.ba_acomba}</span>
+                      {getClientLabel(purchase) && (
+                        <span className="text-gray-700 dark:text-gray-300 font-medium truncate">
+                          {getClientLabel(purchase)}
+                        </span>
                       )}
                       {poNumber && (
                         <>
-                          {purchase.ba_acomba && <span className="text-gray-400">•</span>}
+                          {getClientLabel(purchase) && <span className="text-gray-400">•</span>}
                           <ReferenceLink
                             type="purchase-order"
                             label={`PO: ${poNumber}`}
@@ -842,7 +854,7 @@ export default function SupplierPurchaseManager() {
                           />
                         </>
                       )}
-                      {!purchase.ba_acomba && !poNumber && (
+                      {!getClientLabel(purchase) && !poNumber && (
                         <span className="text-gray-400 italic">Aucune référence</span>
                       )}
                     </div>

--- a/components/SupplierPurchaseServices.js
+++ b/components/SupplierPurchaseServices.js
@@ -2,9 +2,10 @@
  * @file components/SupplierPurchaseServices.js
  * @description Services pour la gestion des achats fournisseurs (AF)
  *              PDF standardisé via pdf-common.js, envoi email, CRUD Supabase
- * @version 2.2.0
- * @date 2026-03-25
+ * @version 2.3.0
+ * @date 2026-08-06
  * @changelog
+ *   2.3.0 - Ajout fetchClients (sélecteur « Ou Client »); PDF affiche « Client » au lieu de « BA Acomba »
  *   2.2.0 - PDF: ajout Transporteur + N° Compte sous adresse livraison, fix date N/A
  *   2.1.0 - Ajout quantités inventaire (en main, en commande, réservé) dans recherche produits
  *   2.0.0 - Standardisation PDF avec pdf-common.js, suppression html2canvas
@@ -433,6 +434,24 @@ export const fetchPurchaseOrders = async () => {
   }
 };
 
+// ===== API SUPABASE - CLIENTS =====
+
+// Récupérer tous les clients (pour le sélecteur « Ou Client » du formulaire AF)
+export const fetchClients = async () => {
+  try {
+    const { data, error } = await supabase
+      .from('clients')
+      .select('id, name, company')
+      .order('name', { ascending: true });
+
+    if (error) throw error;
+    return data || [];
+  } catch (error) {
+    console.error('Erreur chargement clients:', error);
+    throw error;
+  }
+};
+
 // ===== API SUPABASE - ADRESSES DE LIVRAISON =====
 
 // Récupérer toutes les adresses de livraison
@@ -700,8 +719,9 @@ export const generatePurchasePDF = async (purchase, options = {}) => {
   if (purchase.supplier_quote_reference) {
     headerFields.push({ label: 'Soumission:', value: purchase.supplier_quote_reference });
   }
-  if (purchase.ba_acomba) {
-    headerFields.push({ label: 'BA Acomba:', value: purchase.ba_acomba });
+  const pdfClientName = purchase.client_name || purchase.linked_client_name || purchase.purchase_orders?.client_name;
+  if (pdfClientName) {
+    headerFields.push({ label: 'Client:', value: pdfClientName });
   }
   if (purchase.linked_po_number) {
     headerFields.push({ label: 'BA Client:', value: purchase.linked_po_number });

--- a/supabase/migrations/20260806_add_client_to_supplier_purchases.sql
+++ b/supabase/migrations/20260806_add_client_to_supplier_purchases.sql
@@ -1,0 +1,10 @@
+-- Ajout des colonnes client à supplier_purchases (AF)
+-- But: permettre d'associer un client à un Achat Fournisseur même lorsqu'aucun
+--      Bon d'Achat client (BA) n'est lié — pour savoir « pour qui » la commande
+--      est passée. Remplace visuellement le champ « BA Acomba » (retiré du formulaire
+--      et de la liste) par un champ « Client » dans le cadre « Bon d'achat client lié ».
+-- Note: pas de contrainte FK (référence souple, cohérent avec le reste de l'app).
+
+ALTER TABLE supplier_purchases
+  ADD COLUMN IF NOT EXISTS client_id BIGINT,
+  ADD COLUMN IF NOT EXISTS client_name TEXT;


### PR DESCRIPTION
Dans le formulaire d'Achat Fournisseur, cadre « Bon d'achat client lié »: ajout d'un sélecteur « Ou Client » pour associer un client à l'AF même sans BA client lié (auto-rempli depuis le BA quand un BA est sélectionné).

Le champ « BA Acomba » est retiré du formulaire et remplacé par « Client » dans la liste (desktop + mobile), la recherche et le PDF. Le champ ba_acomba est conservé en base et dans le payload pour la rétrocompatibilité.

- Migration 20260806: colonnes client_id + client_name sur supplier_purchases
- SupplierPurchaseServices v2.3.0: fetchClients + PDF « Client »
- SupplierPurchaseHooks: chargement clients + sauvegarde client + recherche
- SupplierPurchaseForms v1.5.0: sélecteur « Ou Client », retrait « BA Acomba »
- SupplierPurchaseManager v1.1.0: colonne « Client »


Claude-Session: https://claude.ai/code/session_01VuVBCYGsvp79Gy214kMF4T