### PR TITLE
Rendre le bouton de réception AF toujours visible sur PC

### DIFF
--- a/app/(protected)/achat-materiels/page.js
+++ b/app/(protected)/achat-materiels/page.js
@@ -5,9 +5,10 @@
  *              - « À Commander »: liste de réapprovisionnement (OrderListManager)
  *              La bascule vers l'onglet AF remonte SupplierPurchaseManager, dont le
  *              hook lit sessionStorage 'af-prefill' au montage pour pré-remplir l'AF.
- * @version 2.0.0
- * @date 2026-07-21
+ * @version 2.1.0
+ * @date 2026-08-07
  * @changelog
+ *   2.1.0 - Élargissement de la vue sur grand écran PC (2xl:max-w-[1600px]) pour laisser plus de place au tableau AF
  *   2.0.0 - Ajout onglet « À Commander » (liste de réapprovisionnement)
  *   1.0.0 - Version initiale (SupplierPurchaseManager seul)
  */
@@ -39,7 +40,7 @@ export default function AchatMaterielsPage() {
   }, []);
 
   return (
-    <div className="max-w-7xl mx-auto px-3 sm:px-4">
+    <div className="max-w-7xl 2xl:max-w-[1600px] mx-auto px-3 sm:px-4">
       {/* Bascule d'onglets */}
       <div className="flex items-center gap-2 mb-4 border-b border-gray-200 dark:border-gray-700">
         <button

--- a/components/SupplierPurchaseManager.js
+++ b/components/SupplierPurchaseManager.js
@@ -4,9 +4,11 @@
  *              - Liste, création, modification, suppression des AF
  *              - Réception directe et réception AF
  *              - Gestion des adresses de livraison fournisseur
- * @version 1.1.0
- * @date 2026-08-06
+ * @version 1.2.0
+ * @date 2026-08-07
  * @changelog
+ *   1.2.0 - Desktop: colonne « Actions » collante à droite (sticky) + défilement horizontal + nom fournisseur tronqué
+ *           → le bouton de réception (camion) reste toujours visible même avec un nom de fournisseur long
  *   1.1.0 - Colonne « BA Acomba » remplacée par « Client » (liste desktop + mobile), recherche par client
  *   1.0.2 - Fix curseur qui saute à la fin lors de la saisie dans les champs avec toUpperCase (CSS textTransform + onBlur)
  *   1.0.1 - Ajout attributs autoCorrect/autoCapitalize/spellCheck sur tous les champs texte
@@ -593,7 +595,7 @@ export default function SupplierPurchaseManager() {
       </div>
 
       {/* Liste des achats - Desktop AVEC DATE DE CRÉATION */}
-      <div className="hidden md:block bg-white dark:bg-gray-900 shadow-lg rounded-lg overflow-hidden">
+      <div className="hidden md:block bg-white dark:bg-gray-900 shadow-lg rounded-lg overflow-x-auto">
         {filteredPurchases.length === 0 ? (
           <div className="text-center py-12">
             <ShoppingCart className="w-16 h-16 mx-auto mb-4 text-gray-300 dark:text-gray-600" />
@@ -611,14 +613,14 @@ export default function SupplierPurchaseManager() {
                 <th className="px-3 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Date Livraison</th>
                 <th className="px-3 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Montant</th>
                 <th className="px-3 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Statut</th>
-                <th className="px-3 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Actions</th>
+                <th className="px-3 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase sticky right-0 z-20 bg-gray-50 dark:bg-gray-800">Actions</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
               {filteredPurchases.map((purchase) => {
                 const poNumber = getPONumber(purchase, purchaseOrders);
                 return (
-                  <tr key={purchase.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                  <tr key={purchase.id} className="group hover:bg-gray-50 dark:hover:bg-gray-800">
                     <td className="px-3 py-4 whitespace-nowrap">
                       <span className="bg-orange-100 text-orange-800 px-2 py-1 rounded text-xs font-medium">
                         {purchase.purchase_number}
@@ -660,7 +662,12 @@ export default function SupplierPurchaseManager() {
                       )}
                     </td>
                     <td className="px-3 py-4">
-                      <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{purchase.supplier_name}</div>
+                      <div
+                        className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate max-w-[220px]"
+                        title={purchase.supplier_name}
+                      >
+                        {purchase.supplier_name}
+                      </div>
                     </td>
                     <td className={`px-3 py-4 text-center text-sm ${
                       purchase.delivery_date && 
@@ -695,7 +702,7 @@ export default function SupplierPurchaseManager() {
                         ))}
                       </select>
                     </td>
-                    <td className="px-3 py-4 text-center">
+                    <td className="px-3 py-4 text-center whitespace-nowrap sticky right-0 z-10 bg-white dark:bg-gray-900 group-hover:bg-gray-50 dark:group-hover:bg-gray-800">
                       <div className="flex justify-center space-x-1">
                         <button
                           onClick={() => handleEditPurchase(purchase)}


### PR DESCRIPTION
## Problème

Sur la vue **PC (desktop)** du module Achats Fournisseurs, un nom de fournisseur trop long faisait déborder le tableau (9 colonnes) vers la droite. La colonne « Actions » était alors coupée par `overflow-hidden`, rendant le **bouton de réception de marchandises (camion vert)** invisible.

## Solution

Quatre mesures combinées pour garantir que le bouton reste **toujours visible** :

1. **Colonne « Actions » collante à droite (`sticky right-0`)** — le bloc Modifier / Supprimer / Réception est épinglé au bord droit et ne peut plus être coupé, quelle que soit la largeur du tableau. Fond opaque (blanc / gris foncé en mode sombre) qui suit le survol de la ligne (`group-hover`).
2. **Conteneur en `overflow-x-auto`** (au lieu de `overflow-hidden`) — filet de sécurité : plus aucun contenu masqué.
3. **Nom de fournisseur tronqué** (`max-w-[220px]` + `truncate`) avec le nom complet en info-bulle (`title`) au survol — empêche la table de gonfler.
4. **Vue élargie sur grand écran PC** (`2xl:max-w-[1600px]`, ≥1536px) — plus d'espace pour la table sur les moniteurs.

## Portée

- **Vue mobile / tablette : inchangée** (le layout mobile a sa propre disposition compacte, non touchée) — conforme à la règle « BT/BL/Achats testés en responsive ».
- Aucune logique métier modifiée : uniquement des classes Tailwind / structure JSX.
- Aucune migration SQL requise.

## Fichiers modifiés

- `components/SupplierPurchaseManager.js` (v1.2.0) — tableau desktop : colonne Actions sticky, `overflow-x-auto`, troncature du nom fournisseur.
- `app/(protected)/achat-materiels/page.js` (v2.1.0) — élargissement de la vue sur grand écran PC.

## Tests

- Build Next.js compilé avec succès (l'unique erreur restante provient des variables d'environnement Supabase absentes du sandbox, sans lien avec ces changements UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs5zekqoN7T9cpPw6yoT5z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cs5zekqoN7T9cpPw6yoT5z)_