### PR TITLE
Ajout du mode de paiement habituel (client) + mode Interac

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -489,6 +489,8 @@ id, name, company, address, travel_minutes,
 contact_name, email, phone,
 contact_name_2, email_2, contact_2,
 contact_name_admin, email_admin, contact_admin,
+hourly_rate_regular, transport_fee, email_billing, payment_terms,
+preferred_payment_method,   -- mode habituel: cheque | virement | interac | comptant (NULL = non spécifié)
 signatory_1..signatory_5
 ```
 
@@ -842,6 +844,14 @@ CRON_SECRET                   # Auth pour cron jobs
     - `components/SupplierPurchaseForms.js` v1.5.0 — `LinkedPOSection`: sélecteur « Ou Client » (auto-rempli depuis le BA lié); retrait du champ « BA Acomba »
     - `components/SupplierPurchaseManager.js` v1.1.0 — colonne « Client » (desktop + mobile) au lieu de « BA Acomba »
     - Note: `ba_acomba` conservé en base (rétrocompat), retiré de l'UI. **Reste:** exécuter la migration SQL dans Supabase Dashboard
+
+26. ~~**Mode de paiement habituel du client + mode Interac**~~ - ✅ COMPLÉTÉ (2026-08-20)
+    - `supabase/migrations/20260820_add_client_payment_method.sql` (nouveau) — `clients.preferred_payment_method` (CHECK cheque/virement/interac/comptant) + `invoice_payments.method` élargi à `interac`
+    - `lib/constants/paymentMethods.js` (nouveau) — liste canonique des modes (Chèque, Virement bancaire, Interac, Comptant, Autre) + `paymentMethodLabel()`
+    - `components/ClientModal.js` v2.2.0 — sélecteur « Mode de paiement habituel » (section Tarification)
+    - `components/invoices/ClientStatementView.js` v1.2.0 — Interac dans le sélecteur de méthode; pastilles « Paiement habituel » + conditions sous le nom du client; mode habituel pré-sélectionné à la saisie
+    - `app/api/statements/[clientId]/route.js` v1.1.0, `app/api/invoice-payments/route.js` v1.1.0, `lib/services/report-data.js` v1.2.0, `lib/services/report-pdf.js` v1.2.0, `app/api/reports/payments/send-email/route.js` v1.1.0
+    - **Reste:** exécuter la migration SQL `20260820_add_client_payment_method.sql` dans Supabase Dashboard
 
 ### À faire (priorité utilisateur)
 6. **Statut soumissions** - Import partiel + changement auto "Acceptée" + ref croisée BA

--- a/RECOMMANDATIONS.md
+++ b/RECOMMANDATIONS.md
@@ -1720,4 +1720,37 @@ Aucune migration SQL requise. Les factures déjà créées gardent leur libellé
 
 ---
 
+## Mode de paiement habituel du client + mode Interac ✅ COMPLETE (2026-08-20)
+
+**Demande (Martin):** ajouter un champ « Mode de paiement habituel » (Chèque / Virement bancaire /
+Interac / Comptant) dans le gestionnaire des clients, ajouter le mode **Interac** aux modes de
+paiement de Facturation → État de compte, et afficher le mode habituel du client dans la page
+État de compte (en description du client).
+
+**Implementation completee (2026-08-20):**
+- `supabase/migrations/20260820_add_client_payment_method.sql` (nouveau) — colonne
+  `clients.preferred_payment_method` (CHECK: cheque/virement/interac/comptant, NULL permis) +
+  contrainte `invoice_payments.method` élargie au mode `interac`.
+- `lib/constants/paymentMethods.js` (nouveau) — liste canonique partagée `PAYMENT_METHODS`
+  (Chèque, Virement bancaire, Interac, Comptant, Autre), `CLIENT_PAYMENT_METHODS` (sans « Autre »,
+  pour la fiche client), `PAYMENT_METHOD_VALUES` (validation API) et `paymentMethodLabel()`.
+- `components/ClientModal.js` v2.2.0 — sélecteur « Mode de paiement habituel » dans la section
+  Tarification (valeur vide = « Non spécifié »).
+- `components/invoices/ClientStatementView.js` v1.2.0 — mode **Interac** dans le sélecteur de
+  méthode; pastilles « Paiement habituel: … » + conditions de paiement sous le nom du client
+  (en-tête de l'état de compte); le mode habituel est **pré-sélectionné** à la saisie d'un paiement
+  et conservé après l'enregistrement; rappel « Habituel: … » sous le sélecteur.
+- `app/api/statements/[clientId]/route.js` v1.1.0 — retourne `preferred_payment_method`.
+- `app/api/invoice-payments/route.js` v1.1.0 — validation du mode via `PAYMENT_METHOD_VALUES`.
+- `lib/services/report-data.js` v1.2.0 — `by_method` inclut `interac`.
+- `lib/services/report-pdf.js` v1.2.0 — `METHOD_LABELS` inclut Interac (et « Virement bancaire »);
+  le sommaire par mode se construit à partir de `METHOD_LABELS` (plus de liste en dur).
+- `app/api/reports/payments/send-email/route.js` v1.1.0 — même sommaire (courriel au comptable).
+
+**Reste:** exécuter la migration SQL `20260820_add_client_payment_method.sql` dans Supabase
+Dashboard (sinon la sauvegarde d'un client échoue: colonne manquante, et un paiement Interac est
+rejeté par la contrainte).
+
+---
+
 *Document genere le 2026-02-05, mis a jour le 2026-08-20 par Claude AI*

--- a/app/api/invoice-payments/route.js
+++ b/app/api/invoice-payments/route.js
@@ -4,14 +4,16 @@
  *              - GET: liste les paiements (filtre invoice_id ou client_id)
  *              - POST: enregistre un paiement (partiel/complet) + recalcule le statut
  *                de la facture (amount_paid, paid/partial/sent)
- * @version 1.0.0
- * @date 2026-06-14
+ * @version 1.1.0
+ * @date 2026-08-20
  * @changelog
+ *   1.1.0 - Modes de paiement validés via la liste partagée (ajout d'Interac)
  *   1.0.0 - Version initiale (module État de compte client)
  */
 
 import { NextResponse } from 'next/server';
 import { supabaseAdmin } from '../../../lib/supabaseAdmin';
+import { PAYMENT_METHOD_VALUES } from '../../../lib/constants/paymentMethods';
 import { recomputeInvoiceStatus } from '../../../lib/services/invoice-payments';
 
 export const dynamic = 'force-dynamic';
@@ -84,7 +86,7 @@ export async function POST(request) {
       );
     }
 
-    if (!['cheque', 'virement', 'comptant', 'autre'].includes(method)) {
+    if (!PAYMENT_METHOD_VALUES.includes(method)) {
       return NextResponse.json(
         { success: false, error: 'Méthode de paiement invalide' },
         { status: 400 }

--- a/app/api/reports/payments/send-email/route.js
+++ b/app/api/reports/payments/send-email/route.js
@@ -3,9 +3,10 @@
  * @description Génère le rapport de paiements (PDF) et l'envoie au comptable (CC bureau).
  *              - print_only: retourne l'URL du PDF sans envoyer de courriel (aperçu)
  *              - Sinon envoie au courriel du comptable (Paramètres) ou à une liste fournie
- * @version 1.0.0
- * @date 2026-06-14
+ * @version 1.1.0
+ * @date 2026-08-20
  * @changelog
+ *   1.1.0 - Sommaire par mode basé sur METHOD_LABELS (inclut Interac)
  *   1.0.0 - Version initiale (rapports comptables ventes/paiements)
  */
 
@@ -79,7 +80,7 @@ export async function POST(request) {
 
     const t = data.totals;
     const bm = t.by_method || {};
-    const methodRows = ['cheque', 'virement', 'comptant', 'autre']
+    const methodRows = Object.keys(METHOD_LABELS)
       .filter(k => (bm[k] || 0) !== 0)
       .map(k => [METHOD_LABELS[k], `${(bm[k] || 0).toFixed(2)} $`]);
 

--- a/app/api/statements/[clientId]/route.js
+++ b/app/api/statements/[clientId]/route.js
@@ -3,9 +3,10 @@
  * @description API état de compte détaillé d'un client
  *              - GET: client + factures ouvertes (solde > 0) avec paiements appliqués,
  *                jours de retard, intérêts, tranches de vieillissement (aging) et totaux.
- * @version 1.0.0
- * @date 2026-06-14
+ * @version 1.1.0
+ * @date 2026-08-20
  * @changelog
+ *   1.1.0 - Retourne le mode de paiement habituel du client (preferred_payment_method)
  *   1.0.0 - Version initiale (module État de compte client)
  */
 
@@ -29,7 +30,7 @@ export async function GET(request, { params }) {
     // Client + coordonnées + courriels
     const { data: client, error: clientErr } = await supabaseAdmin
       .from('clients')
-      .select('id, name, company, address, email, email_billing, email_admin, email_2, email_3, contact_name, contact_name_2, contact_name_3, contact_name_admin, phone, payment_terms')
+      .select('id, name, company, address, email, email_billing, email_admin, email_2, email_3, contact_name, contact_name_2, contact_name_3, contact_name_admin, phone, payment_terms, preferred_payment_method')
       .eq('id', parseInt(clientId))
       .single();
 

--- a/components/ClientModal.js
+++ b/components/ClientModal.js
@@ -6,9 +6,11 @@
  *              - 5 signataires autorisés
  *              - Formatage automatique des numéros de téléphone
  *              - email_admin optionnel
- * @version 2.1.0
- * @date 2026-03-07
+ * @version 2.2.0
+ * @date 2026-08-20
  * @changelog
+ *   2.2.0 - Ajout du champ « Mode de paiement habituel » (Chèque / Virement bancaire /
+ *           Interac / Comptant) dans la section Tarification
  *   2.1.0 - Ajout attributs autoCorrect/autoCapitalize/spellCheck sur tous les champs texte
  *   2.0.1 - Fix: ContactSection causait perte de focus (rendu fonction au lieu de composant)
  *   2.0.0 - Ajout Tarification + Contact #3 + email_admin optionnel (Phase A)
@@ -18,6 +20,12 @@
 'use client';
 import { useState, useEffect } from 'react';
 import { X, User, Users, Building, PenTool, DollarSign } from 'lucide-react';
+import { CLIENT_PAYMENT_METHODS } from '../lib/constants/paymentMethods';
+
+const PAYMENT_METHOD_OPTIONS = [
+  { value: '', label: 'Non spécifié' },
+  ...CLIENT_PAYMENT_METHODS,
+];
 
 const PAYMENT_TERMS_OPTIONS = [
   { value: '', label: 'Par défaut (voir Paramètres)' },
@@ -51,6 +59,7 @@ const EMPTY_FORM = {
   transport_fee: '',
   email_billing: '',
   payment_terms: '',
+  preferred_payment_method: '',
   // Signataires
   signatory_1: '',
   signatory_2: '',
@@ -80,6 +89,7 @@ function clientToForm(client) {
     transport_fee: client.transport_fee ?? '',
     email_billing: client.email_billing || '',
     payment_terms: client.payment_terms || '',
+    preferred_payment_method: client.preferred_payment_method || '',
     signatory_1: client.signatory_1 || '',
     signatory_2: client.signatory_2 || '',
     signatory_3: client.signatory_3 || '',
@@ -171,6 +181,7 @@ export default function ClientModal({ open, onClose, onSaved, client }) {
         transport_fee: form.transport_fee !== '' ? parseFloat(form.transport_fee) : null,
         email_billing: form.email_billing?.trim() || null,
         payment_terms: form.payment_terms || null,
+        preferred_payment_method: form.preferred_payment_method || null,
         // Signataires
         signatory_1: form.signatory_1?.trim() || '',
         signatory_2: form.signatory_2?.trim() || '',
@@ -504,6 +515,25 @@ export default function ClientModal({ open, onClose, onSaved, client }) {
                         <option key={opt.value} value={opt.value}>{opt.label}</option>
                       ))}
                     </select>
+                  </div>
+
+                  {/* Mode de paiement habituel */}
+                  <div>
+                    <label className="block text-sm font-medium text-emerald-800 dark:text-emerald-300 mb-1">
+                      Mode de paiement habituel
+                    </label>
+                    <select
+                      className={`${inputBase} border-emerald-300 dark:border-emerald-600 focus:border-emerald-500 focus:ring-emerald-200 dark:focus:ring-emerald-800`}
+                      value={form.preferred_payment_method}
+                      onChange={onChange('preferred_payment_method')}
+                    >
+                      {PAYMENT_METHOD_OPTIONS.map(opt => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                      ))}
+                    </select>
+                    <p className="text-xs text-emerald-600 dark:text-emerald-400 mt-1">
+                      Affiché à l&apos;état de compte (Facturation)
+                    </p>
                   </div>
                 </div>
               </div>

--- a/components/invoices/ClientStatementView.js
+++ b/components/invoices/ClientStatementView.js
@@ -7,9 +7,12 @@
  *              - Historique des paiements appliqués (suppression possible)
  *              - Aperçu PDF + envoi du relevé par courriel (destinataires du dossier client)
  *              - Mobile-first: champs numériques auto-select, touch targets 44px
- * @version 1.1.0
- * @date 2026-06-14
+ * @version 1.2.0
+ * @date 2026-08-20
  * @changelog
+ *   1.2.0 - Mode de paiement Interac ajouté (liste partagée lib/constants/paymentMethods)
+ *           + pastilles sous le nom du client (mode de paiement habituel, conditions de
+ *           paiement) et pré-sélection du mode habituel à la saisie d'un paiement
  *   1.1.0 - Rendu via portail (document.body) pour échapper au conteneur
  *           overflow-hidden + backdrop-blur de l'onglet (en-tête/boutons coupés)
  *   1.0.0 - Version initiale (module État de compte client)
@@ -21,15 +24,11 @@ import { useState, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import {
   X, RefreshCw, AlertCircle, CheckCircle, Trash2, Send, Eye,
-  DollarSign, Clock, Mail, Plus,
+  DollarSign, Clock, Mail, Plus, CreditCard,
 } from 'lucide-react';
+import { PAYMENT_METHODS, paymentMethodLabel } from '../../lib/constants/paymentMethods';
 
-const METHODS = [
-  { value: 'cheque', label: 'Chèque' },
-  { value: 'virement', label: 'Virement' },
-  { value: 'comptant', label: 'Comptant' },
-  { value: 'autre', label: 'Autre' },
-];
+const METHODS = PAYMENT_METHODS;
 
 const BUCKET_LABELS = {
   current: 'Courant',
@@ -91,6 +90,9 @@ export default function ClientStatementView({ clientId, onClose, onChanged }) {
       const json = await res.json();
       if (json.success) {
         setData(json.data);
+        // Pré-sélectionner le mode de paiement habituel du client (fiche client)
+        const usual = json.data?.client?.preferred_payment_method;
+        if (usual) setPay(p => ({ ...p, method: usual }));
         // Réinitialiser les allocations
         const a = {};
         (json.data.invoices || []).forEach(inv => {
@@ -190,7 +192,12 @@ export default function ClientStatementView({ clientId, onClose, onChanged }) {
         }
       }
       setSuccess('Paiement(s) enregistré(s)');
-      setPay({ payment_date: todayStr(), method: 'cheque', reference: '', notes: '' });
+      setPay({
+        payment_date: todayStr(),
+        method: data?.client?.preferred_payment_method || 'cheque',
+        reference: '',
+        notes: '',
+      });
       await load();
       onChanged?.();
     } catch (err) {
@@ -316,6 +323,22 @@ export default function ClientStatementView({ clientId, onClose, onChanged }) {
             <div className="min-w-0">
               <h2 className="text-lg font-bold text-white truncate">État de compte</h2>
               <p className="text-emerald-50 text-sm truncate">{data?.client?.name || '...'}</p>
+              {/* Description du client: mode de paiement habituel + conditions */}
+              <div className="flex flex-wrap items-center gap-1.5 mt-1">
+                <span className="inline-flex items-center gap-1 bg-white/20 text-white text-[11px] sm:text-xs px-2 py-0.5 rounded-full">
+                  <CreditCard className="w-3 h-3" />
+                  Paiement habituel:{' '}
+                  {data?.client?.preferred_payment_method
+                    ? paymentMethodLabel(data.client.preferred_payment_method)
+                    : 'non spécifié'}
+                </span>
+                {data?.client?.payment_terms && (
+                  <span className="inline-flex items-center gap-1 bg-white/20 text-white text-[11px] sm:text-xs px-2 py-0.5 rounded-full">
+                    <Clock className="w-3 h-3" />
+                    {data.client.payment_terms}
+                  </span>
+                )}
+              </div>
             </div>
           </div>
           <button
@@ -417,6 +440,11 @@ export default function ClientStatementView({ clientId, onClose, onChanged }) {
                     >
                       {METHODS.map(m => <option key={m.value} value={m.value}>{m.label}</option>)}
                     </select>
+                    {data?.client?.preferred_payment_method && (
+                      <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-1">
+                        Habituel: {paymentMethodLabel(data.client.preferred_payment_method)}
+                      </p>
+                    )}
                   </div>
                   <div>
                     <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">N° chèque / virement</label>

--- a/lib/constants/paymentMethods.js
+++ b/lib/constants/paymentMethods.js
@@ -1,0 +1,38 @@
+/**
+ * @file lib/constants/paymentMethods.js
+ * @description Liste canonique des modes de paiement (source unique).
+ *              - PAYMENT_METHODS: modes utilisables pour un paiement reçu
+ *                (Chèque, Virement bancaire, Interac, Comptant, Autre)
+ *              - CLIENT_PAYMENT_METHODS: modes proposés comme « mode de paiement
+ *                habituel » dans la fiche client (sans « Autre »)
+ *              - paymentMethodLabel(): libellé fr-CA d'un code de mode
+ * @version 1.0.0
+ * @date 2026-08-20
+ * @changelog
+ *   1.0.0 - Version initiale (ajout du mode Interac + mode habituel du client)
+ */
+
+// Modes acceptés lors de la saisie d'un paiement (État de compte)
+export const PAYMENT_METHODS = [
+  { value: 'cheque', label: 'Chèque' },
+  { value: 'virement', label: 'Virement bancaire' },
+  { value: 'interac', label: 'Interac' },
+  { value: 'comptant', label: 'Comptant' },
+  { value: 'autre', label: 'Autre' },
+];
+
+// Modes proposés pour le « mode de paiement habituel » d'un client
+// (« Autre » exclu: sans valeur informative sur une fiche client)
+export const CLIENT_PAYMENT_METHODS = PAYMENT_METHODS.filter(m => m.value !== 'autre');
+
+// Codes valides pour un paiement (validation API)
+export const PAYMENT_METHOD_VALUES = PAYMENT_METHODS.map(m => m.value);
+
+/**
+ * Libellé lisible d'un code de mode de paiement.
+ * Retourne le code brut si inconnu, '' si vide.
+ */
+export function paymentMethodLabel(value) {
+  if (!value) return '';
+  return PAYMENT_METHODS.find(m => m.value === value)?.label || value;
+}

--- a/lib/services/report-data.js
+++ b/lib/services/report-data.js
@@ -7,9 +7,10 @@
  *              La ventilation des ventes (matériel / M.O. / déplacement / forfait-autre) est
  *              calculée à partir des line_items de chaque facture, pour toujours réconcilier
  *              avec le sous-total (forfait + lignes « autre » inclus).
- * @version 1.1.0
- * @date 2026-06-14
+ * @version 1.2.0
+ * @date 2026-08-20
  * @changelog
+ *   1.2.0 - Ventilation des paiements: mode Interac ajouté à by_method
  *   1.1.0 - Ventilation des ventes calculée depuis line_items (+ colonne Forfait/Autre)
  *           pour réconcilier avec le sous-total. Corrige les factures prix forfaitaire (Jobe)
  *           qui affichaient 0 partout. Fallback sur les colonnes stockées si line_items vide.
@@ -163,7 +164,7 @@ async function buildPaymentsReport(searchParams) {
   }, {
     amount: 0,
     discount: 0,
-    by_method: { cheque: 0, virement: 0, comptant: 0, autre: 0 },
+    by_method: { cheque: 0, virement: 0, interac: 0, comptant: 0, autre: 0 },
   });
 
   totals.amount = Math.round(totals.amount * 100) / 100;

--- a/lib/services/report-pdf.js
+++ b/lib/services/report-pdf.js
@@ -6,9 +6,10 @@
  *              - En-tête/footer standardisés via pdf-common.js.
  *              - Rapport de ventes: 1 ligne / facture + ligne TOTAUX.
  *              - Rapport de paiements: 1 ligne / paiement + TOTAUX + sous-totaux par mode.
- * @version 1.1.0
- * @date 2026-06-14
+ * @version 1.2.0
+ * @date 2026-08-20
  * @changelog
+ *   1.2.0 - Mode de paiement Interac ajouté au sommaire (libellé « Virement bancaire »)
  *   1.1.0 - Rapport de ventes: ajout colonne « Forfait/Autre » (réconcilie le sous-total)
  *   1.0.0 - Version initiale (rapports comptables ventes/paiements)
  */
@@ -19,9 +20,12 @@ const pdfCommon = require('./pdf-common');
 
 const { CONTENT_WIDTH, COLORS, PAGE, FONT } = pdfCommon;
 
+// Doit rester aligné avec lib/constants/paymentMethods.js
+// (module CommonJS requis côté serveur: liste dupliquée volontairement)
 const METHOD_LABELS = {
   cheque: 'Chèque',
-  virement: 'Virement',
+  virement: 'Virement bancaire',
+  interac: 'Interac',
   comptant: 'Comptant',
   autre: 'Autre',
 };
@@ -275,7 +279,7 @@ function buildPaymentsReportDoc(data, logoBase64) {
   y = pdfCommon.drawSectionTitle(doc, 'SOMMAIRE PAR MODE DE PAIEMENT', y);
 
   const bm = totals.by_method || {};
-  const methodRows = ['cheque', 'virement', 'comptant', 'autre']
+  const methodRows = Object.keys(METHOD_LABELS)
     .filter(k => (bm[k] || 0) !== 0)
     .map(k => ({ mode: METHOD_LABELS[k], amount: fmt(bm[k]) }));
 

--- a/supabase/migrations/20260820_add_client_payment_method.sql
+++ b/supabase/migrations/20260820_add_client_payment_method.sql
@@ -1,0 +1,22 @@
+-- ============================================
+-- Mode de paiement habituel du client + mode Interac
+-- Date: 2026-08-20
+-- Description: Ajoute clients.preferred_payment_method (mode de paiement habituel)
+--              et autorise le mode 'interac' sur invoice_payments.
+-- ============================================
+
+-- 1. Mode de paiement habituel du client (informatif, affiché à l'état de compte)
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS preferred_payment_method TEXT;
+
+ALTER TABLE clients DROP CONSTRAINT IF EXISTS clients_preferred_payment_method_check;
+ALTER TABLE clients ADD CONSTRAINT clients_preferred_payment_method_check
+  CHECK (
+    preferred_payment_method IS NULL
+    OR preferred_payment_method = ''
+    OR preferred_payment_method IN ('cheque', 'virement', 'interac', 'comptant')
+  );
+
+-- 2. Nouveau mode de paiement 'interac' sur les paiements de factures
+ALTER TABLE invoice_payments DROP CONSTRAINT IF EXISTS invoice_payments_method_check;
+ALTER TABLE invoice_payments ADD CONSTRAINT invoice_payments_method_check
+  CHECK (method IN ('cheque', 'virement', 'interac', 'comptant', 'autre'));


### PR DESCRIPTION
- Fiche client: nouveau champ « Mode de paiement habituel » (Chèque / Virement bancaire / Interac / Comptant), section Tarification
- Facturation → État de compte: mode Interac disponible à la saisie d'un paiement, et mode habituel du client affiché en pastille sous son nom (avec les conditions de paiement) + pré-sélectionné dans le sélecteur
- Liste canonique partagée des modes de paiement (lib/constants/paymentMethods.js)
- Rapports comptables (PDF + courriel): Interac inclus au sommaire par mode
- Migration SQL: clients.preferred_payment_method + contrainte invoice_payments.method élargie à 'interac'


Claude-Session: https://claude.ai/code/session_016BguzKFhiwKcGuFxEUPK7i