### PR TITLE
Etat de compte: destinataires visibles + adresses memorisees au dossier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -494,6 +494,7 @@ contact_name_2, email_2, contact_2,
 contact_name_admin, email_admin, contact_admin,
 hourly_rate_regular, transport_fee, email_billing, payment_terms,
 preferred_payment_method,   -- mode habituel: cheque | virement | interac | comptant (NULL = non spécifié)
+additional_emails,          -- JSONB [{email, label}]: adresses supplémentaires (ex. 2e admin)
 signatory_1..signatory_5
 ```
 
@@ -865,6 +866,14 @@ CRON_SECRET                   # Auth pour cron jobs
     - `app/api/statements/[clientId]/send-email/route.js` v1.3.0 — `include_interest` (défaut true) dans le body
     - Standard respecté: relevé « open item » **à une date** — une facture de juin impayée figure bien sur un relevé au 31 juillet (tranche 31-60 j), intérêts arrêtés à la date du relevé; vieillissement basé sur la date d'échéance
     - Défaut inchangé: date du jour (fuseau Québec). Aucune migration SQL requise
+
+28. ~~**Destinataires de l'état de compte + adresses courriel supplémentaires**~~ - ✅ COMPLÉTÉ (2026-08-20)
+    - `supabase/migrations/20260820b_add_client_additional_emails.sql` (nouveau) — `clients.additional_emails` JSONB `[{email, label}]`, nombre illimité (couvre « plus d'une adresse d'administration »)
+    - `app/api/statements/[clientId]/send-email/route.js` v1.4.0 — `save_to_client` (défaut true): après envoi réussi, une adresse absente du dossier est écrite dans `email_admin` s'il est vide, sinon ajoutée à `additional_emails`; insensible à la casse, best-effort (n'annule jamais l'envoi), retourne `saved_emails`
+    - `components/invoices/ClientStatementView.js` v1.5.0 — fenêtre d'envoi: cases à cocher (nom + rôle: Facturation/Principal/#2/#3/Administration/Supplémentaire), ajout de **plusieurs** adresses à la volée (pastilles retirables), case « Ajouter au dossier client », encadré « Envoi à (n) » + copie au bureau
+    - `components/ClientModal.js` v2.3.0 — section « Courriels supplémentaires » (adresse + libellé, ajout/retrait)
+    - `lib/services/statement-data.js` v1.1.0 — retourne `additional_emails`
+    - **Reste:** exécuter la migration SQL `20260820b_add_client_additional_emails.sql` dans Supabase Dashboard
 
 ### À faire (priorité utilisateur)
 6. **Statut soumissions** - Import partiel + changement auto "Acceptée" + ref croisée BA

--- a/RECOMMANDATIONS.md
+++ b/RECOMMANDATIONS.md
@@ -1805,4 +1805,43 @@ Aucune migration SQL requise.
 
 ---
 
+### Destinataires de l'état de compte + adresses supplémentaires au dossier ✅ COMPLETE (2026-08-20)
+
+**Demande utilisateur (Martin):** voir clairement à qui part l'état de compte, pouvoir cocher les
+courriels du dossier client **et/ou** en ajouter un qui n'y est pas, et que cette nouvelle adresse
+soit **mémorisée au dossier** — dans un champ vide, ou comme adresse d'administration, avec la
+possibilité d'en avoir **plus d'une**.
+
+**Implémentation (2026-08-20):**
+
+- `supabase/migrations/20260820b_add_client_additional_emails.sql` (nouveau) — colonne
+  `clients.additional_emails` (JSONB, défaut `[]`), format `[{email, label}]`. Nombre d'adresses
+  illimité, sans multiplier les colonnes. `clients` figure déjà dans le backup quotidien: aucune
+  modification requise de `app/api/cron/backup/route.ts` (ajout de colonne, pas de table).
+- `lib/services/statement-data.js` v1.1.0 — retourne `additional_emails`.
+- `app/api/statements/[clientId]/send-email/route.js` v1.4.0 — `save_to_client` (défaut true):
+  après un **envoi réussi**, toute adresse utilisée absente du dossier est enregistrée —
+  `email_admin` s'il est vide (première adresse), sinon ajout à `additional_emails` avec le libellé
+  « Administration ». Comparaison insensible à la casse, dédoublonnage dans le même envoi,
+  best-effort (un échec d'écriture n'annule jamais l'envoi). La réponse renvoie `saved_emails`.
+- `components/invoices/ClientStatementView.js` v1.5.0 — fenêtre d'envoi refaite:
+  - liste à cocher des courriels du dossier avec **nom du contact + rôle** (Facturation, Principal,
+    Contact #2/#3, Administration, Supplémentaire), adresses supplémentaires incluses;
+  - ajout de **plusieurs** adresses à la volée (champ + bouton Ajouter, touche Entrée, pastilles
+    retirables) au lieu d'une seule;
+  - case **« Ajouter cette adresse au dossier client »** (cochée par défaut), qui annonce où
+    l'adresse ira (champ Administration vide, sinon adresse supplémentaire);
+  - encadré récapitulatif **« Envoi à (n) »** listant les destinataires définitifs + « copie au
+    bureau », et bouton Envoyer désactivé s'il n'y a personne;
+  - une adresse tapée mais pas encore « ajoutée » est quand même incluse à l'envoi (rien ne se perd);
+  - rechargement automatique du dossier après un envoi qui a enrichi le client.
+- `components/ClientModal.js` v2.3.0 — section **« Courriels supplémentaires »**: liste
+  adresse + libellé, ajout/retrait, pour corriger une faute de frappe ou gérer plusieurs adresses
+  d'administration à la main.
+
+**Reste:** exécuter la migration SQL `20260820b_add_client_additional_emails.sql` dans Supabase
+Dashboard (sinon l'ajout automatique d'adresse échoue: colonne manquante).
+
+---
+
 *Document genere le 2026-02-05, mis a jour le 2026-08-20 par Claude AI*

--- a/app/api/statements/[clientId]/send-email/route.js
+++ b/app/api/statements/[clientId]/send-email/route.js
@@ -10,9 +10,14 @@
  *                exclut les factures émises après cette date et les paiements postérieurs
  *              - Body include_interest (défaut true): à false, aucun intérêt de retard n'est
  *                facturé ni mentionné (PDF + courriel) — geste commercial pour un bon client
- * @version 1.3.0
+ *              - Body save_to_client (défaut true): une adresse saisie à la volée est
+ *                enregistrée au dossier client (email_admin s'il est vide, sinon
+ *                additional_emails) pour être proposée aux prochains envois
+ * @version 1.4.0
  * @date 2026-08-20
  * @changelog
+ *   1.4.0 - Enregistrement au dossier client des adresses ajoutées à la volée
+ *           (save_to_client) + retour de la liste des adresses ajoutées
  *   1.3.0 - Intérêts de retard optionnels (include_interest): total = solde des factures,
  *           ni ligne d'intérêts ni avis de taux dans le PDF, ni mention dans le courriel
  *   1.2.0 - Date du relevé (as_of): aperçu et courriel générés à la date choisie à l'écran
@@ -49,6 +54,65 @@ function formatDateFr(dateStr) {
   if (!dateStr) return '-';
   const [y, m, d] = dateStr.split('-');
   return `${parseInt(d)} ${MONTHS_FR[parseInt(m)]} ${y}`;
+}
+
+/**
+ * Enregistre au dossier client les adresses utilisées qui n'y figurent pas encore.
+ * - Remplit `email_admin` s'il est vide (première adresse seulement)
+ * - Sinon ajoute à `additional_emails` (liste illimitée, libellée « Administration »)
+ *
+ * Best-effort: un échec n'empêche jamais l'envoi du relevé.
+ *
+ * @returns {Promise<string[]>} adresses effectivement ajoutées au dossier
+ */
+async function saveNewEmailsToClient(clientId, client, usedEmails) {
+  const norm = (e) => String(e || '').trim().toLowerCase();
+
+  const existing = new Set(
+    [client.email, client.email_2, client.email_3, client.email_admin, client.email_billing]
+      .concat((client.additional_emails || []).map(a => a?.email))
+      .filter(Boolean)
+      .map(norm)
+  );
+
+  // Dédoublonner les nouvelles adresses entre elles
+  const fresh = [];
+  for (const e of usedEmails) {
+    const n = norm(e);
+    if (!n || existing.has(n)) continue;
+    existing.add(n);
+    fresh.push(String(e).trim());
+  }
+  if (fresh.length === 0) return [];
+
+  const updates = {};
+  const additional = Array.isArray(client.additional_emails) ? [...client.additional_emails] : [];
+  let remaining = fresh;
+
+  // Champ Administration vide: la première adresse y va
+  if (!client.email_admin) {
+    updates.email_admin = fresh[0];
+    remaining = fresh.slice(1);
+  }
+  for (const e of remaining) {
+    additional.push({ email: e, label: 'Administration' });
+  }
+  if (additional.length !== (client.additional_emails || []).length) {
+    updates.additional_emails = additional;
+  }
+
+  if (Object.keys(updates).length === 0) return [];
+
+  const { error } = await supabaseAdmin
+    .from('clients')
+    .update(updates)
+    .eq('id', parseInt(clientId));
+
+  if (error) {
+    console.error('Enregistrement des courriels au dossier client échoué:', error.message);
+    return [];
+  }
+  return fresh;
 }
 
 /**
@@ -262,13 +326,14 @@ function generateStatementPDF(statement) {
 
 /**
  * POST /api/statements/[clientId]/send-email
- * Body: { emails?: string[], print_only?: boolean, as_of?: 'YYYY-MM-DD', include_interest?: boolean }
+ * Body: { emails?: string[], print_only?: boolean, as_of?: 'YYYY-MM-DD',
+ *         include_interest?: boolean, save_to_client?: boolean }
  */
 export async function POST(request, { params }) {
   try {
     const { clientId } = params;
     const body = await request.json();
-    const { emails: customEmails, print_only, as_of, include_interest } = body;
+    const { emails: customEmails, print_only, as_of, include_interest, save_to_client } = body;
     // Intérêts facturés par défaut; false = geste commercial (aucune mention nulle part)
     const chargeInterest = include_interest !== false;
 
@@ -289,6 +354,7 @@ export async function POST(request, { params }) {
 
     // Déterminer les destinataires (sauf en aperçu)
     let emailAddresses = [];
+    let savedEmails = [];
     if (!print_only) {
       if (customEmails && customEmails.length > 0) {
         emailAddresses = customEmails.filter(Boolean);
@@ -400,6 +466,15 @@ export async function POST(request, { params }) {
           { status: 500 }
         );
       }
+
+      // Mémoriser au dossier client les adresses saisies à la volée (après envoi réussi)
+      if (save_to_client !== false) {
+        try {
+          savedEmails = await saveNewEmailsToClient(clientId, statement.client, emailAddresses);
+        } catch (saveErr) {
+          console.error('Enregistrement des courriels (non bloquant):', saveErr.message);
+        }
+      }
     }
 
     if (print_only) {
@@ -414,11 +489,15 @@ export async function POST(request, { params }) {
     }
 
     const ccNote = process.env.COMPANY_EMAIL ? ` (copie au bureau: ${process.env.COMPANY_EMAIL})` : '';
+    const savedNote = savedEmails.length > 0
+      ? ` — ${savedEmails.length > 1 ? 'adresses ajoutées' : 'adresse ajoutée'} au dossier client: ${savedEmails.join(', ')}`
+      : '';
     return NextResponse.json({
       success: true,
+      saved_emails: savedEmails,
       message: `État de compte au ${formatDateFr(statement.statementDate)}${
         !chargeInterest && statement.totals.interest > 0 ? ' (sans intérêts de retard)' : ''
-      } envoyé à ${emailAddresses.join(', ')}${ccNote}`,
+      } envoyé à ${emailAddresses.join(', ')}${ccNote}${savedNote}`,
       sentTo: emailAddresses,
       cc: process.env.COMPANY_EMAIL || null,
       pdf_url: pdfUrl,

--- a/components/ClientModal.js
+++ b/components/ClientModal.js
@@ -6,9 +6,13 @@
  *              - 5 signataires autorisés
  *              - Formatage automatique des numéros de téléphone
  *              - email_admin optionnel
- * @version 2.2.0
+ *              - Courriels supplémentaires illimités (additional_emails, JSONB)
+ * @version 2.3.0
  * @date 2026-08-20
  * @changelog
+ *   2.3.0 - Section « Courriels supplémentaires »: plus d'une adresse d'administration par
+ *           client (liste illimitée, ajout/retrait); alimentée aussi automatiquement à
+ *           l'envoi d'un état de compte
  *   2.2.0 - Ajout du champ « Mode de paiement habituel » (Chèque / Virement bancaire /
  *           Interac / Comptant) dans la section Tarification
  *   2.1.0 - Ajout attributs autoCorrect/autoCapitalize/spellCheck sur tous les champs texte
@@ -19,7 +23,7 @@
  */
 'use client';
 import { useState, useEffect } from 'react';
-import { X, User, Users, Building, PenTool, DollarSign } from 'lucide-react';
+import { X, User, Users, Building, PenTool, DollarSign, Mail, Plus } from 'lucide-react';
 import { CLIENT_PAYMENT_METHODS } from '../lib/constants/paymentMethods';
 
 const PAYMENT_METHOD_OPTIONS = [
@@ -54,6 +58,8 @@ const EMPTY_FORM = {
   contact_name_admin: '',
   email_admin: '',
   contact_admin: '',
+  // Courriels supplémentaires: [{ email, label }]
+  additional_emails: [],
   // Tarification
   hourly_rate_regular: '',
   transport_fee: '',
@@ -85,6 +91,7 @@ function clientToForm(client) {
     contact_name_admin: client.contact_name_admin || '',
     email_admin: client.email_admin || '',
     contact_admin: client.contact_admin || '',
+    additional_emails: Array.isArray(client.additional_emails) ? client.additional_emails : [],
     hourly_rate_regular: client.hourly_rate_regular ?? '',
     transport_fee: client.transport_fee ?? '',
     email_billing: client.email_billing || '',
@@ -176,6 +183,10 @@ export default function ClientModal({ open, onClose, onSaved, client }) {
         contact_name_admin: form.contact_name_admin?.trim() || '',
         email_admin: form.email_admin?.trim() || '',
         contact_admin: form.contact_admin?.trim() || '',
+        // Courriels supplémentaires (nettoyés)
+        additional_emails: (form.additional_emails || [])
+          .map(a => ({ email: (a?.email || '').trim(), label: (a?.label || '').trim() || 'Administration' }))
+          .filter(a => a.email),
         // Tarification
         hourly_rate_regular: form.hourly_rate_regular !== '' ? parseFloat(form.hourly_rate_regular) : null,
         transport_fee: form.transport_fee !== '' ? parseFloat(form.transport_fee) : null,
@@ -240,6 +251,30 @@ export default function ClientModal({ open, onClose, onSaved, client }) {
       text: 'text-purple-800 dark:text-purple-300',
       icon: 'text-purple-600 dark:text-purple-400',
     },
+  };
+
+  /* ---------- Courriels supplémentaires ---------- */
+  const setExtraEmail = (index, field) => (e) => {
+    const value = e.target.value;
+    setForm(prev => {
+      const list = [...(prev.additional_emails || [])];
+      list[index] = { ...list[index], [field]: value };
+      return { ...prev, additional_emails: list };
+    });
+  };
+
+  const addExtraEmailRow = () => {
+    setForm(prev => ({
+      ...prev,
+      additional_emails: [...(prev.additional_emails || []), { email: '', label: 'Administration' }],
+    }));
+  };
+
+  const removeExtraEmailRow = (index) => {
+    setForm(prev => ({
+      ...prev,
+      additional_emails: (prev.additional_emails || []).filter((_, i) => i !== index),
+    }));
   };
 
   // Fonction de rendu (PAS un composant React — évite le remount à chaque render)
@@ -416,6 +451,62 @@ export default function ClientModal({ open, onClose, onSaved, client }) {
                   { label: 'Courriel Admin', key: 'email_admin', type: 'email', placeholder: 'admin@exemple.com' },
                   { label: 'Contact Admin', key: 'contact_admin', type: 'tel', placeholder: '(418) 225-3875' },
                 ])}
+              </div>
+
+              {/* SECTION - Courriels supplémentaires (plus d'une adresse d'administration) */}
+              <div className="bg-purple-50 dark:bg-purple-900/20 border border-purple-200 dark:border-purple-700 p-4 rounded-lg">
+                <h3 className="text-lg font-semibold text-purple-800 dark:text-purple-300 mb-1 flex items-center">
+                  <Mail className="w-5 h-5 mr-2 text-purple-600 dark:text-purple-400" />
+                  Courriels supplémentaires
+                </h3>
+                <p className="text-xs text-purple-700 dark:text-purple-400 mb-3">
+                  Adresses additionnelles proposées à l&apos;envoi des états de compte (2e adresse
+                  d&apos;administration, comptable du client, etc.).
+                </p>
+
+                <div className="space-y-2">
+                  {(form.additional_emails || []).length === 0 && (
+                    <p className="text-sm text-gray-500 dark:text-gray-400">Aucune adresse supplémentaire.</p>
+                  )}
+                  {(form.additional_emails || []).map((row, i) => (
+                    <div key={i} className="flex flex-col sm:flex-row gap-2">
+                      <input
+                        type="email"
+                        className={`${inputBase} border-purple-200 dark:border-purple-700 flex-1`}
+                        value={row?.email || ''}
+                        onChange={setExtraEmail(i, 'email')}
+                        placeholder="compta@exemple.com"
+                        autoComplete="email"
+                        inputMode="email"
+                        autoCorrect="off" autoCapitalize="off" spellCheck={false}
+                      />
+                      <input
+                        type="text"
+                        className={`${inputBase} border-purple-200 dark:border-purple-700 sm:w-48`}
+                        value={row?.label || ''}
+                        onChange={setExtraEmail(i, 'label')}
+                        placeholder="Administration"
+                        autoCorrect="on" autoCapitalize="sentences" spellCheck={true}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removeExtraEmailRow(i)}
+                        className="min-h-[44px] px-3 rounded-lg text-sm font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50 inline-flex items-center justify-center gap-1"
+                        title="Retirer cette adresse"
+                      >
+                        <X className="w-4 h-4" /> Retirer
+                      </button>
+                    </div>
+                  ))}
+                </div>
+
+                <button
+                  type="button"
+                  onClick={addExtraEmailRow}
+                  className="mt-3 min-h-[44px] px-4 py-2 rounded-lg text-sm font-medium bg-purple-100 dark:bg-purple-900/40 text-purple-800 dark:text-purple-300 hover:bg-purple-200 dark:hover:bg-purple-900/60 inline-flex items-center gap-2"
+                >
+                  <Plus className="w-4 h-4" /> Ajouter une adresse
+                </button>
               </div>
 
               {/* SECTION - Tarification */}

--- a/components/invoices/ClientStatementView.js
+++ b/components/invoices/ClientStatementView.js
@@ -5,15 +5,21 @@
  *              - Saisie d'un paiement (chèque/virement/comptant) couvrant une ou
  *                plusieurs factures, avec escompte 2% optionnel par facture
  *              - Historique des paiements appliqués (suppression possible)
- *              - Aperçu PDF + envoi du relevé par courriel (destinataires du dossier client)
+ *              - Envoi par courriel: destinataires du dossier client à cocher (nom + rôle),
+ *                ajout d'adresses hors dossier, récapitulatif « Envoi à », et mémorisation
+ *                automatique des nouvelles adresses au dossier client
  *              - Date du relevé sélectionnable (ex. 31 juillet): l'écran, l'aperçu PDF et
  *                le courriel montrent alors le compte tel qu'il était à cette date
  *              - Case « Facturer les intérêts de retard »: décochée = relevé sans intérêts
  *                (geste commercial pour un bon client en léger retard)
  *              - Mobile-first: champs numériques auto-select, touch targets 44px
- * @version 1.4.0
+ * @version 1.5.0
  * @date 2026-08-20
  * @changelog
+ *   1.5.0 - Fenêtre d'envoi refaite: rôle affiché par adresse (Facturation/Principal/#2/#3/
+ *           Administration/Supplémentaire), ajout de plusieurs adresses hors dossier
+ *           (pastilles retirables), case « Ajouter au dossier client » (save_to_client),
+ *           récapitulatif « Envoi à (n) » + copie au bureau
  *   1.4.0 - Case à cocher « Facturer les intérêts de retard » (décochée = aucun intérêt sur
  *           l'écran, l'aperçu PDF et le courriel); remise à cochée à chaque rechargement
  *   1.3.0 - Sélecteur « Date du relevé » (+ raccourcis Aujourd'hui / Fin du mois dernier),
@@ -110,6 +116,9 @@ export default function ClientStatementView({ clientId, onClose, onChanged }) {
   const [showSend, setShowSend] = useState(false);
   const [selectedEmails, setSelectedEmails] = useState([]);
   const [customEmail, setCustomEmail] = useState('');
+  // Adresses ajoutées à la volée (hors dossier client) + mémorisation au dossier
+  const [extraEmails, setExtraEmails] = useState([]);
+  const [saveToClient, setSaveToClient] = useState(true);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -282,8 +291,16 @@ export default function ClientStatementView({ clientId, onClose, onChanged }) {
   };
 
   const sendStatement = async () => {
-    const emails = [...selectedEmails];
-    if (customEmail.trim()) emails.push(customEmail.trim());
+    // Inclure une adresse tapée mais pas encore ajoutée (évite de la perdre)
+    const pending = customEmail.trim();
+    const emails = [...selectedEmails, ...extraEmails];
+    if (pending && !emails.some(e => e.toLowerCase() === pending.toLowerCase())) {
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(pending)) {
+        setError('Adresse courriel invalide');
+        return;
+      }
+      emails.push(pending);
+    }
     if (emails.length === 0) {
       setError('Sélectionnez au moins un destinataire');
       return;
@@ -294,12 +311,21 @@ export default function ClientStatementView({ clientId, onClose, onChanged }) {
       const res = await fetch(`/api/statements/${clientId}/send-email`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ emails, as_of: asOf, include_interest: chargeInterest }),
+        body: JSON.stringify({
+          emails,
+          as_of: asOf,
+          include_interest: chargeInterest,
+          save_to_client: saveToClient,
+        }),
       });
       const json = await res.json();
       if (json.success) {
         setSuccess(json.message || 'État de compte envoyé');
         setShowSend(false);
+        setCustomEmail('');
+        setExtraEmails([]);
+        // Le dossier client vient d'être enrichi: recharger pour proposer les nouvelles adresses
+        if (json.saved_emails?.length > 0) load();
       } else {
         setError(json.error || 'Erreur envoi');
       }
@@ -310,33 +336,79 @@ export default function ClientStatementView({ clientId, onClose, onChanged }) {
     }
   };
 
-  // Destinataires disponibles (courriels du dossier client)
+  // Destinataires disponibles (courriels du dossier client, incl. adresses supplémentaires)
   const availableEmails = (() => {
     const c = data?.client;
     if (!c) return [];
     const items = [
-      { email: c.email_billing, label: 'Facturation' },
-      { email: c.email, label: c.contact_name || 'Principal' },
-      { email: c.email_2, label: c.contact_name_2 || 'Contact 2' },
-      { email: c.email_3, label: c.contact_name_3 || 'Contact 3' },
-      { email: c.email_admin, label: c.contact_name_admin || 'Administration' },
+      { email: c.email_billing, label: 'Facturation', role: 'Facturation' },
+      { email: c.email, label: c.contact_name || 'Contact principal', role: 'Principal' },
+      { email: c.email_2, label: c.contact_name_2 || 'Contact #2', role: 'Contact #2' },
+      { email: c.email_3, label: c.contact_name_3 || 'Contact #3', role: 'Contact #3' },
+      { email: c.email_admin, label: c.contact_name_admin || 'Administration', role: 'Administration' },
+      ...(Array.isArray(c.additional_emails) ? c.additional_emails : []).map(a => ({
+        email: a?.email,
+        label: a?.label || 'Administration',
+        role: 'Supplémentaire',
+      })),
     ].filter(x => x.email);
-    // Dédoublonner par adresse
+    // Dédoublonner par adresse (insensible à la casse)
     const seen = new Set();
-    return items.filter(x => (seen.has(x.email) ? false : seen.add(x.email)));
+    return items.filter(x => {
+      const k = x.email.trim().toLowerCase();
+      if (seen.has(k)) return false;
+      seen.add(k);
+      return true;
+    });
   })();
 
   const openSend = () => {
     // Pré-cocher l'email de facturation (ou le premier disponible)
-    const def = availableEmails.find(e => e.label === 'Facturation') || availableEmails[0];
+    const def = availableEmails.find(e => e.role === 'Facturation') || availableEmails[0];
     setSelectedEmails(def ? [def.email] : []);
     setCustomEmail('');
+    setExtraEmails([]);
+    setSaveToClient(true);
     setShowSend(true);
   };
 
   const toggleEmail = (email) => {
     setSelectedEmails(prev => prev.includes(email) ? prev.filter(e => e !== email) : [...prev, email]);
   };
+
+  // Adresses hors dossier client ajoutées à la volée
+  const knownEmail = (email) => {
+    const k = email.trim().toLowerCase();
+    return availableEmails.some(e => e.email.trim().toLowerCase() === k)
+      || extraEmails.some(e => e.toLowerCase() === k);
+  };
+
+  const addExtraEmail = () => {
+    const value = customEmail.trim();
+    if (!value) return;
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+      setError('Adresse courriel invalide');
+      return;
+    }
+    if (knownEmail(value)) {
+      setError('Cette adresse est déjà dans la liste');
+      return;
+    }
+    setExtraEmails(prev => [...prev, value]);
+    setCustomEmail('');
+    setError(null);
+  };
+
+  const removeExtraEmail = (email) => {
+    setExtraEmails(prev => prev.filter(e => e !== email));
+  };
+
+  // Liste définitive des destinataires (dossier coché + ajouts)
+  const finalRecipients = [...selectedEmails, ...extraEmails];
+  // Adresses qui seront mémorisées au dossier client
+  const newForClient = extraEmails.filter(e => !availableEmails.some(
+    a => a.email.trim().toLowerCase() === e.toLowerCase()
+  ));
 
   const rawTotals = data?.totals || { balance: 0, interest: 0, total_with_interest: 0, open_count: 0 };
   // Intérêts non facturés: le total à payer se limite au solde des factures
@@ -778,37 +850,112 @@ export default function ClientStatementView({ clientId, onClose, onChanged }) {
                 )}
               </span>
             </div>
-            <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">Choisissez les destinataires:</p>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">Courriels au dossier client:</p>
             <div className="space-y-2 mb-3">
               {availableEmails.length === 0 && (
-                <p className="text-sm text-amber-600 dark:text-amber-400">Aucun courriel au dossier client. Saisissez une adresse ci-dessous.</p>
+                <p className="text-sm text-amber-600 dark:text-amber-400">Aucun courriel au dossier client. Ajoutez une adresse ci-dessous.</p>
               )}
               {availableEmails.map(e => (
-                <label key={e.email} className="flex items-center gap-3 p-2 rounded-lg border border-gray-200 dark:border-gray-700 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800">
+                <label key={e.email} className="flex items-center gap-3 p-2 rounded-lg border border-gray-200 dark:border-gray-700 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 min-h-[44px]">
                   <input
                     type="checkbox"
                     checked={selectedEmails.includes(e.email)}
                     onChange={() => toggleEmail(e.email)}
-                    className="w-5 h-5 rounded accent-indigo-600"
+                    className="w-5 h-5 rounded accent-indigo-600 flex-shrink-0"
                   />
-                  <span className="min-w-0">
+                  <span className="min-w-0 flex-1">
                     <span className="block text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{e.email}</span>
-                    <span className="block text-xs text-gray-500 dark:text-gray-400">{e.label}</span>
+                    <span className="block text-xs text-gray-500 dark:text-gray-400 truncate">
+                      {e.label}{e.label !== e.role ? ` · ${e.role}` : ''}
+                    </span>
                   </span>
                 </label>
               ))}
             </div>
-            <div className="mb-4">
-              <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Autre adresse (optionnel)</label>
-              <input
-                type="email"
-                value={customEmail}
-                onChange={(e) => setCustomEmail(e.target.value)}
-                onFocus={(e) => e.target.select()}
-                placeholder="courriel@exemple.com"
-                autoCorrect="off" autoCapitalize="off" spellCheck={false}
-                className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm"
-              />
+
+            {/* Adresses ajoutées à la volée */}
+            <div className="mb-3">
+              <label htmlFor="statement-extra-email" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                Ajouter une autre adresse (hors dossier)
+              </label>
+              <div className="flex gap-2">
+                <input
+                  id="statement-extra-email"
+                  type="email"
+                  value={customEmail}
+                  onChange={(e) => setCustomEmail(e.target.value)}
+                  onFocus={(e) => e.target.select()}
+                  onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addExtraEmail(); } }}
+                  placeholder="courriel@exemple.com"
+                  inputMode="email"
+                  autoCorrect="off" autoCapitalize="off" spellCheck={false}
+                  className="flex-1 min-h-[44px] px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm"
+                />
+                <button
+                  type="button"
+                  onClick={addExtraEmail}
+                  disabled={!customEmail.trim()}
+                  className="min-h-[44px] px-3 rounded-lg text-sm font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600 inline-flex items-center gap-1 disabled:opacity-50"
+                >
+                  <Plus className="w-4 h-4" /> Ajouter
+                </button>
+              </div>
+              {extraEmails.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mt-2">
+                  {extraEmails.map(e => (
+                    <span key={e} className="inline-flex items-center gap-1 bg-indigo-100 dark:bg-indigo-900/40 text-indigo-800 dark:text-indigo-300 text-xs px-2 py-1 rounded-full">
+                      {e}
+                      <button
+                        type="button"
+                        onClick={() => removeExtraEmail(e)}
+                        className="p-0.5 rounded-full hover:bg-indigo-200 dark:hover:bg-indigo-800"
+                        title="Retirer"
+                      >
+                        <X className="w-3 h-3" />
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Mémoriser au dossier client */}
+            {newForClient.length > 0 && (
+              <label className="flex items-start gap-2.5 mb-3 cursor-pointer select-none min-h-[44px] py-1">
+                <input
+                  type="checkbox"
+                  checked={saveToClient}
+                  onChange={(e) => setSaveToClient(e.target.checked)}
+                  className="w-5 h-5 mt-0.5 rounded accent-emerald-600 flex-shrink-0"
+                />
+                <span className="text-sm text-gray-700 dark:text-gray-300">
+                  Ajouter {newForClient.length > 1 ? 'ces adresses' : 'cette adresse'} au dossier client
+                  <span className="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    {data?.client?.email_admin
+                      ? 'Sera enregistrée comme adresse d\u2019administration supplémentaire.'
+                      : 'Le champ Administration du dossier est vide: l\u2019adresse ira là.'}
+                  </span>
+                </span>
+              </label>
+            )}
+
+            {/* Récapitulatif: à qui ça part */}
+            <div className="mb-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 px-3 py-2">
+              <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+                Envoi à ({finalRecipients.length})
+              </div>
+              {finalRecipients.length === 0 ? (
+                <p className="text-sm text-amber-600 dark:text-amber-400">Aucun destinataire sélectionné</p>
+              ) : (
+                <ul className="space-y-0.5">
+                  {finalRecipients.map(e => (
+                    <li key={e} className="text-sm text-gray-900 dark:text-gray-100 truncate flex items-center gap-1.5">
+                      <Mail className="w-3 h-3 flex-shrink-0 text-gray-400" /> {e}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">+ copie au bureau</p>
             </div>
             <div className="flex gap-2 justify-end">
               <button onClick={() => setShowSend(false)} className="min-h-[44px] px-4 py-2 rounded-lg text-sm font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600">
@@ -816,7 +963,7 @@ export default function ClientStatementView({ clientId, onClose, onChanged }) {
               </button>
               <button
                 onClick={sendStatement}
-                disabled={busy}
+                disabled={busy || (finalRecipients.length === 0 && !customEmail.trim())}
                 className="min-h-[44px] px-4 py-2 rounded-lg text-sm font-medium bg-indigo-600 text-white hover:bg-indigo-700 inline-flex items-center gap-2 disabled:opacity-50"
               >
                 {busy ? <RefreshCw className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}

--- a/lib/services/statement-data.js
+++ b/lib/services/statement-data.js
@@ -7,9 +7,10 @@
  *              - Retard, intérêts et vieillissement (aging) calculés par rapport à as_of.
  *              - Partagé par GET /api/statements/[clientId] et l'envoi/aperçu PDF,
  *                pour garantir que l'aperçu et le courriel correspondent à l'écran.
- * @version 1.0.0
+ * @version 1.1.0
  * @date 2026-08-20
  * @changelog
+ *   1.1.0 - Retourne additional_emails (adresses supplémentaires du dossier client)
  *   1.0.0 - Version initiale (extraction + filtre par date du relevé)
  */
 
@@ -59,7 +60,7 @@ async function buildStatement(supabaseAdmin, clientId, options = {}) {
 
   const { data: client, error: clientErr } = await supabaseAdmin
     .from('clients')
-    .select('id, name, company, address, email, email_billing, email_admin, email_2, email_3, contact_name, contact_name_2, contact_name_3, contact_name_admin, phone, payment_terms, preferred_payment_method')
+    .select('id, name, company, address, email, email_billing, email_admin, email_2, email_3, additional_emails, contact_name, contact_name_2, contact_name_3, contact_name_admin, phone, payment_terms, preferred_payment_method')
     .eq('id', id)
     .single();
 

--- a/supabase/migrations/20260820b_add_client_additional_emails.sql
+++ b/supabase/migrations/20260820b_add_client_additional_emails.sql
@@ -1,0 +1,18 @@
+-- ============================================
+-- Adresses courriel supplémentaires par client
+-- Date: 2026-08-20
+-- Description: Permet d'enregistrer plus d'une adresse « administration » (ou toute autre
+--              adresse additionnelle) dans le dossier client, sans multiplier les colonnes.
+--              Alimenté automatiquement quand on ajoute un destinataire à la volée lors de
+--              l'envoi d'un état de compte, et modifiable dans la fiche client.
+-- Format: [{ "email": "compta@client.com", "label": "Administration" }, ...]
+-- ============================================
+
+ALTER TABLE clients
+  ADD COLUMN IF NOT EXISTS additional_emails JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN clients.additional_emails IS
+  'Adresses courriel supplémentaires: [{email, label}]. Complète email, email_2, email_3, email_admin et email_billing.';
+
+-- Sécurité: normaliser d'éventuelles valeurs NULL héritées
+UPDATE clients SET additional_emails = '[]'::jsonb WHERE additional_emails IS NULL;


### PR DESCRIPTION
Martin veut voir a qui part le releve, cocher les courriels du dossier client et/ou en ajouter un qui n'y est pas, et que cette nouvelle adresse soit retenue pour la prochaine fois -- avec plus d'une adresse d'administration possible.

Dossier client:
- nouvelle colonne clients.additional_emails (JSONB [{email, label}]), nombre d'adresses illimite sans multiplier les colonnes;
- ClientModal: section "Courriels supplementaires" (adresse + libelle, ajout/retrait) pour corriger une faute de frappe ou en gerer plusieurs a la main.

Fenetre d'envoi de l'etat de compte:
- cases a cocher avec nom du contact ET role (Facturation, Principal, Contact #2/#3, Administration, Supplementaire);
- ajout de plusieurs adresses hors dossier (champ + bouton, touche Entree, pastilles retirables) au lieu d'une seule;
- case "Ajouter cette adresse au dossier client" (cochee par defaut) qui annonce ou l'adresse ira;
- encadre "Envoi a (n)" listant les destinataires definitifs + copie au bureau, bouton Envoyer desactive s'il n'y a personne;
- une adresse tapee mais pas encore "ajoutee" est quand meme incluse.

Cote serveur (save_to_client, defaut true): apres un envoi reussi, une adresse absente du dossier va dans email_admin s'il est vide, sinon dans additional_emails. Comparaison insensible a la casse, dedoublonnage dans le meme envoi, best-effort -- un echec d'ecriture n'annule jamais l'envoi.

Migration SQL a executer: 20260820b_add_client_additional_emails.sql


Claude-Session: https://claude.ai/code/session_0119CUXodyD5g5zu9VxcJd3i